### PR TITLE
Switch to a more stable branch for delphyne-use-libprotobuf.

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -6,6 +6,6 @@ repositories:
   ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: 'default' }
   ign_math        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-math.git',          version: 'ign-math3' }
   ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: 'default' }
-  drake           : { type: 'git', url: 'https://github.com/osrf/drake.git',                            version: 'use-libprotobuf' }
+  drake           : { type: 'git', url: 'https://github.com/osrf/drake.git',                            version: 'delphyne-use-libprotobuf' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'master' }
   delphyne-gui    : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',      version: 'master' }


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>