### PR TITLE
Pin the ignition libraries to particular versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ but in brief:
 
 # Setup the environment
 In order to successfully build and use Delphyne, Drake, or the ignition tools
-here, a few environment variables must be setup. Delphyne GIO provides a script
-to do this for you; for this to work correctly, you must be in the root of your
-delphyne workspace:
+here, a few environment variables must be setup. Delphyne GUI provides a script
+to do this for you; for this to work correctly, your current working directory
+must be somewhere within the delphyne workspace:
 
 ```
 $ . src/delphyne_gui/setup.bash
@@ -93,8 +93,9 @@ The Delphyne back-end can now be built with CMake:
 $ pushd build
 $ mkdir -p delphyne
 $ pushd delphyne
-$ cmake ../../src/delphyne/ -DCMAKE_INSTALL_PREFIX=../../install -DDRAKE_INSTALL_PREFIX=</path/to/delphyne_ws/install_drake
+$ cmake ../../src/delphyne/ -DCMAKE_INSTALL_PREFIX=../../install -DDRAKE_INSTALL_PREFIX=../../install_drake
 $ make -j$( getconf _NPROCESSORS_ONLN ) install
+$ popd
 $ popd
 ```
 
@@ -108,6 +109,8 @@ $ mkdir -p delphyne_gui
 $ pushd delphyne_gui
 $ cmake ../../src/delphyne_gui/ -DCMAKE_INSTALL_PREFIX=../../install
 $ make -j$( getconf _NPROCESSORS_ONLN ) install
+$ popd
+$ popd
 ```
 
 The Visualizer will be installed in `<delphyne_ws>/install/bin`.

--- a/delphyne.repos
+++ b/delphyne.repos
@@ -1,11 +1,11 @@
 repositories:
-  ign_common      : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-common.git',        version: 'default' }
-  ign_transport   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-transport.git',     version: 'default' }
-  ign_tools       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-tools.git',         version: 'default' }
-  ign_gui         : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: 'default' }
-  ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: 'default' }
-  ign_math        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-math.git',          version: 'ign-math3' }
-  ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: 'default' }
+  ign_common      : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-common.git',        version: '76d416addd2f' }
+  ign_transport   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-transport.git',     version: '1a9c29ac2b91' }
+  ign_tools       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-tools.git',         version: '22d5bada1e36' }
+  ign_gui         : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: '709d1e3dc7b1' }
+  ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: 'c1582502bc2e' }
+  ign_math        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-math.git',          version: 'c65a11981d87' }
+  ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: '1bad2f95d538' }
   drake           : { type: 'git', url: 'https://github.com/osrf/drake.git',                            version: 'delphyne-use-libprotobuf' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'master' }
-  delphyne-gui    : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',      version: 'master' }
+  delphyne_gui    : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',      version: 'master' }


### PR DESCRIPTION
This is to avoid unexpected changes in the upstream libraries
to affect us directly.

While we are at it, cleanup README.md a bit.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>