### PR TITLE
Put in another necessary bazel drake build command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ following:
 ```
 $ pushd src/drake
 $ bazel run //:install </path/to/delphyne_ws>/install_drake
+$ bazel build //drake/automotive:*
 $ popd
 ```
 


### PR DESCRIPTION
Otherwise, the `automotive_demo` and `steering_command_driver` portions of drake aren't built.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>