### PR TITLE
Use a different branch for drake protobuf stuff.

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -6,6 +6,6 @@ repositories:
   ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: 'c1582502bc2e' }
   ign_math        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-math.git',          version: 'c65a11981d87' }
   ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: '1bad2f95d538' }
-  drake           : { type: 'git', url: 'https://github.com/osrf/drake.git',                            version: 'delphyne-use-libprotobuf' }
+  drake           : { type: 'git', url: 'https://github.com/osrf/drake.git',                            version: 'delphyne-use-libprotobuf2' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'master' }
   delphyne_gui    : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',      version: 'master' }


### PR DESCRIPTION
We have to leave the old branch in place so that we don't
break v0.2.0.  But we want to rebase the branch so that we
have the newest changes from drake.  Thus, we introduce a
new branch and switch to that.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>