### PR TITLE
Cherry-pick of #20 to AutomotiveSimulatorPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ $ . src/delphyne_gui/setup.bash
 
 Next we can go on and build the components.
 
+# Build and install drake
+
+Drake must be built using the Bazel build tool. To build drake, do the
+following:
+
+```
+$ pushd src/drake
+$ bazel run //:install `pwd`/../../install
+$ bazel build //drake/automotive:*
+$ popd
+```
+
+Note that this will take a long time to compile.
+
 # Build dependencies
 
 Delphyne depends on a number of external dependencies. To make the tools and
@@ -64,27 +78,13 @@ commands:
 ```
 $ mkdir -p build
 $ pushd build
-$ for igndep in ign_tools ign_math ign_common ign_msgs ign_transport ign_gui ign_rendering; do mkdir -p $igndep ; pushd $igndep ; cmake ../../src/$igndep -DCMAKE_INSTALL_PREFIX=../../install ; make -j$( getconf _NPROCESSORS_ONLN ) install ; popd ; done
+$ for igndep in ign_tools ign_common ign_msgs ign_transport ign_gui ign_rendering; do mkdir -p $igndep ; pushd $igndep ; cmake ../../src/$igndep -DCMAKE_INSTALL_PREFIX=../../install ; make -j$( getconf _NPROCESSORS_ONLN ) install ; popd ; done
 $ popd
 ```
 
 This may take a little while to build the dependencies. At the end of the build,
 a new subdirectory called `install` will be at the top level of your
 delphyne workspace.
-
-# Build and install drake
-
-Drake must be built using the Bazel build tool. To build drake, do the
-following:
-
-```
-$ pushd src/drake
-$ bazel run //:install `pwd`/../../install_drake
-$ bazel build //drake/automotive:*
-$ popd
-```
-
-Note that this will take a long time to compile.
 
 # Build Delphyne back-end
 
@@ -93,7 +93,7 @@ The Delphyne back-end can now be built with CMake:
 ```
 $ mkdir -p build/delphyne
 $ pushd build/delphyne
-$ cmake ../../src/delphyne/ -DCMAKE_INSTALL_PREFIX=../../install -DDRAKE_INSTALL_PREFIX=../../install_drake
+$ cmake ../../src/delphyne/ -DCMAKE_INSTALL_PREFIX=../../install
 $ make -j$( getconf _NPROCESSORS_ONLN ) install
 $ popd
 ```

--- a/delphyne.repos
+++ b/delphyne.repos
@@ -4,7 +4,6 @@ repositories:
   ign_tools       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-tools.git',         version: '22d5bada1e36' }
   ign_gui         : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: '709d1e3dc7b1' }
   ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: 'c1582502bc2e' }
-  ign_math        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-math.git',          version: 'c65a11981d87' }
   ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: '1bad2f95d538' }
   drake           : { type: 'git', url: 'https://github.com/osrf/drake.git',                            version: 'delphyne-use-libprotobuf2' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'AutomotiveSimulatorPort' }

--- a/setup.bash
+++ b/setup.bash
@@ -48,16 +48,13 @@ add_if_not_in_var() {
     fi
 }
 
-export DRAKE_INSTALL_PATH=$WS_DIR/install_drake
 export DELPHYNE_WS_DIR=$WS_DIR
 export DRAKE_SRC_DIR=$WS_DIR/src/drake
 add_if_not_in_var PATH $WS_DIR/install/bin
-add_if_not_in_var PATH $WS_DIR/install_drake/bin
-add_if_not_in_var LD_LIBRARY_PATH $WS_DIR/install_drake/lib
 add_if_not_in_var LD_LIBRARY_PATH $WS_DIR/install/lib
 add_if_not_in_var DELPHYNE_PACKAGE_PATH $WS_DIR/src/drake/drake/automotive/models
 add_if_not_in_var DELPHYNE_PACKAGE_PATH $WS_DIR/src/delphyne/bridge
 add_if_not_in_var DELPHYNE_PACKAGE_PATH $WS_DIR/src/delphyne
 add_if_not_in_var DELPHYNE_PACKAGE_PATH $WS_DIR/src/delphyne_gui
 add_if_not_in_var PYTHONPATH $WS_DIR/install/lib/python2.7/site-packages/launcher
-add_if_not_in_var PYTHONPATH $WS_DIR/install_drake/lib/python2.7/site-packages
+add_if_not_in_var PYTHONPATH $WS_DIR/install/lib/python2.7/site-packages


### PR DESCRIPTION
This cherry picks da7d71c0de953b86a5565961045d438417d7ad83 as it is needed for the DRAKE_INSTALL_PATH to point to the right place to get the demos to work (note that it was needed because I followed the master's readme instad of the AutomotiveSimulatorPort's one).

Though maybe it doesnt make sense to port bite-size PRs and would be better to reconcile them when this branch is ready for merging. 