### PR TITLE
Set the DELPHYNE_AGENT_PLUGIN_PATH in the environment.

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -51,6 +51,7 @@ add_if_not_in_var() {
 export DRAKE_INSTALL_PATH=$WS_DIR/install
 export DELPHYNE_WS_DIR=$WS_DIR
 export DRAKE_SRC_DIR=$WS_DIR/src/drake
+export DELPHYNE_AGENT_PLUGIN_PATH=$WS_DIR/install/lib/delphyne/agents
 add_if_not_in_var PATH $WS_DIR/install/bin
 add_if_not_in_var LD_LIBRARY_PATH $WS_DIR/install/lib
 add_if_not_in_var DELPHYNE_PACKAGE_PATH $WS_DIR/install/share/drake/automotive/models


### PR DESCRIPTION
We need this environment variable to find the installed loadable agents.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>