### PR TITLE
Update Ignition Common, GUI and hide extra fields in scene tree widget.

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -1,8 +1,8 @@
 repositories:
-  ign_common      : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-common.git',        version: 'b68e5361c7b1' }
+  ign_common      : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-common.git',        version: '3818a10e35c1' }
   ign_transport   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-transport.git',     version: '1ee754b31aff' }
   ign_tools       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-tools.git',         version: '22d5bada1e36' }
-  ign_gui         : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: 'f5d7b0e3fee1' }
+  ign_gui         : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: 'd1f308f9736e' }
   ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: 'f70b3f5b73ba' }
   ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: 'e3d3e320c527' }
   ign_cmake       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-cmake.git',         version: 'db89652250ed' }

--- a/visualizer/initialLayout.config
+++ b/visualizer/initialLayout.config
@@ -191,12 +191,44 @@
   <hide>origin_visual</hide>
   <hide>joint</hide>
   <hide>model::header</hide>
+  <hide>model::id</hide>
+  <hide>model::is_static</hide>
   <hide>model::deleted</hide>
   <hide>model::visual</hide>
   <hide>model::scale</hide>
+  <hide>model::self_collide</hide>
   <hide>model::model</hide>
-  <hide>light::header</hide>
+  <hide>model::link::header</hide>
+  <hide>model::link::id</hide>
+  <hide>model::link::self_collide</hide>
+  <hide>model::link::gravity</hide>
+  <hide>model::link::kinematic</hide>
+  <hide>model::link::enabled</hide>
+  <hide>model::link::density</hide>
+  <hide>model::link::inertial</hide>
+  <hide>model::link::visual</hide>
+  <hide>model::link::collision</hide>
+  <hide>model::link::sensor</hide>
+  <hide>model::link::projector</hide>
+  <hide>model::link::canonical</hide>
+  <hide>model::link::battery</hide>
+  <hide>model::joint::header</hide>
+  <hide>model::joint::id</hide>
+  <hide>model::joint::parent_id</hide>
+  <hide>model::joint::child_id</hide>
+  <hide>model::joint::cfm</hide>
+  <hide>model::joint::bounce</hide>
+  <hide>model::joint::fudge_factor</hide>
+  <hide>model::joint::limit_cfm</hide>
+  <hide>model::joint::limit_erp</hide>
+  <hide>model::joint::suspension_cfm</hide>
+  <hide>model::joint::suspension_erp</hide>
+  <hide>model::joint::gearbox</hide>
+  <hide>model::joint::screw</hide>
+  <hide>model::joint::sensor</hide>
+  <hide>light</hide>
 </plugin>
+
 
 <plugin filename="TopicsStats"/>
 <plugin filename="TopicViewer"/>

--- a/visualizer/layoutWithTeleop.config
+++ b/visualizer/layoutWithTeleop.config
@@ -191,14 +191,46 @@
   <hide>shadows</hide>
   <hide>fog</hide>
   <hide>grid</hide>
+  <hide>joint</hide>
   <hide>origin_visual</hide>
   <hide>joint</hide>
   <hide>model::header</hide>
+  <hide>model::id</hide>
+  <hide>model::is_static</hide>
   <hide>model::deleted</hide>
   <hide>model::visual</hide>
   <hide>model::scale</hide>
+  <hide>model::self_collide</hide>
   <hide>model::model</hide>
-  <hide>light::header</hide>
+  <hide>model::link::header</hide>
+  <hide>model::link::id</hide>
+  <hide>model::link::self_collide</hide>
+  <hide>model::link::gravity</hide>
+  <hide>model::link::kinematic</hide>
+  <hide>model::link::enabled</hide>
+  <hide>model::link::density</hide>
+  <hide>model::link::inertial</hide>
+  <hide>model::link::visual</hide>
+  <hide>model::link::collision</hide>
+  <hide>model::link::sensor</hide>
+  <hide>model::link::projector</hide>
+  <hide>model::link::canonical</hide>
+  <hide>model::link::battery</hide>
+  <hide>model::joint::header</hide>
+  <hide>model::joint::id</hide>
+  <hide>model::joint::parent_id</hide>
+  <hide>model::joint::child_id</hide>
+  <hide>model::joint::cfm</hide>
+  <hide>model::joint::bounce</hide>
+  <hide>model::joint::fudge_factor</hide>
+  <hide>model::joint::limit_cfm</hide>
+  <hide>model::joint::limit_erp</hide>
+  <hide>model::joint::suspension_cfm</hide>
+  <hide>model::joint::suspension_erp</hide>
+  <hide>model::joint::gearbox</hide>
+  <hide>model::joint::screw</hide>
+  <hide>model::joint::sensor</hide>
+  <hide>light</hide>
 </plugin>
 
 <plugin filename="TopicsStats"/>


### PR DESCRIPTION
Update Ignition Common, Ignition GUI and hide extra fields in the scene tree widget.

The updates in Common and GUI solve an issue in the plotting tool. All plots should be continuous now.