### PR TITLE
Use drake's pybind11

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -6,7 +6,6 @@ repositories:
   ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: '83faf9206fdd' }
   ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: '043b69f902f6' }
   ign_cmake       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-cmake.git',         version: 'c4a7896c4622' }
-  pybind11        : { type: 'git', url: 'https://github.com/RobotLocomotion/pybind11.git',              version: '3dcfcb00a440e858211661d179a15904586fb45f' }
   drake           : { type: 'git', url: 'https://github.com/RobotLocomotion/drake.git',                 version: '84066107e966e2336c1fa8adf18e4c2fb203586e' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'master' }
   delphyne_gui    : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',      version: 'master' }


### PR DESCRIPTION
- Removes pybind11 from delphyne.repos
This PR goes hand-with-hand with [delphyne's #351](https://github.com/ToyotaResearchInstitute/delphyne/pull/351) and fixes the first item from [delphyne's metaissue #344](https://github.com/ToyotaResearchInstitute/delphyne/issues/344)