### PR TITLE
Change backend scene RPC endpoint name

### DIFF
--- a/visualizer/RenderWidget.cc
+++ b/visualizer/RenderWidget.cc
@@ -32,8 +32,8 @@
 
 #include "RenderWidget.hh"
 
-Q_DECLARE_METATYPE(ignition::msgs::Scene)
 Q_DECLARE_METATYPE(ignition::msgs::Model_V)
+Q_DECLARE_METATYPE(ignition::msgs::Scene)
 
 using namespace delphyne;
 using namespace gui;
@@ -150,7 +150,7 @@ RenderWidget::RenderWidget(QWidget* parent)
   // Setting up a unique-named service name
   // i.e: Scene_8493201843;
   int randomId = ignition::math::Rand::IntUniform(1, ignition::math::MAX_I32);
-  sceneServiceName += "_" + std::to_string(randomId);
+  std::string sceneServiceName = "Scene_" + std::to_string(randomId);
   sceneRequestMsg.set_response_topic(sceneServiceName);
 
    // Advertise the service with the unique name generated above

--- a/visualizer/RenderWidget.hh
+++ b/visualizer/RenderWidget.hh
@@ -26,9 +26,9 @@ class XMLElement;
 }
 namespace ignition {
 namespace msgs {
-class Scene;
-class Model_V;
 class Model;
+class Model_V;
+class Scene;
 class Visual;
 }
 }
@@ -257,9 +257,6 @@ class RenderWidget : public ignition::gui::Plugin {
 
   /// \brief Is the scene initialized?.
   bool initializedScene;
-
-  /// \brief The name of the response topic for SceneRequest
-  std::string sceneServiceName = "Scene";
 
   /// \brief The scene request message to be sent to the backend
   ignition::msgs::SceneRequest sceneRequestMsg;


### PR DESCRIPTION
`/get_robot_models` is now called `/get_scene`, and returns an `ignition::msgs::Scene` instead of an `ignition::msgs::Model_V`. Since a `Model_V` is a subset of a `Scene` (i.e. `Scene`'s `model` field is the same as `Model_V`'s `models`), this is mostly trivial. Some methods were renamed to reflect this change.

Goes hand in hand with https://github.com/ToyotaResearchInstitute/delphyne/pull/358