### PR TITLE
User lower case for the Ignition Transport topics

### DIFF
--- a/visualizer/RenderWidget.cc
+++ b/visualizer/RenderWidget.cc
@@ -541,7 +541,7 @@ void RenderWidget::SetInitialModels(const ignition::msgs::Model_V& _msg) {
     LoadModel(_msg.models(i));
   }
 
-  this->node.Subscribe("/drake_viewer_draw", &RenderWidget::OnUpdateScene,
+  this->node.Subscribe("visualizer/scene_update", &RenderWidget::OnUpdateScene,
                        this);
 }
 

--- a/visualizer/TeleopWidget.cc
+++ b/visualizer/TeleopWidget.cc
@@ -28,7 +28,7 @@ TeleopWidget::TeleopWidget(QWidget* parent)
   this->title = "TeleopWidget";
 
   this->lineedit = new QLineEdit();
-  this->lineedit->setText("driving_command_0");
+  this->lineedit->setText("teleop/0");
 
   this->button = new QPushButton("Start Driving");
 
@@ -62,7 +62,7 @@ void TeleopWidget::LoadConfig(const tinyxml2::XMLElement* _pluginElem) {
   if (_pluginElem) {
     if (auto channelElem = _pluginElem->FirstChildElement("car_number")) {
       std::string channelName =
-          "driving_command_" + std::string(channelElem->GetText());
+          "teleop/" + std::string(channelElem->GetText());
       this->lineedit->setText(QString::fromStdString(channelName));
     }
   }


### PR DESCRIPTION
Use with [# 360](https://github.com/ToyotaResearchInstitute/delphyne/pull/360) in Delphyne.

The following topics/prefixes/suffixes have been converted to lowercase:

* `DRIVING_COMMAND`
* `DRAKE_VIEWER_DRAW`