### PR TITLE
[infra] no need for major version any longer in find_package(delphyne)

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -133,5 +133,4 @@ endif()
 
 ########################################
 # Find Delphyne
-find_package(delphyne0 REQUIRED)
-message(STATUS "Looking for Delphyne.....${delphyne0_FOUND}")
+find_package(delphyne REQUIRED)


### PR DESCRIPTION
If we do need it, it's now settable by the usual `find_package(delphyne [version] REQUIRED)` functionality.