### PR TITLE
Introspect non-Ignition::Msgs topics

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -4,7 +4,7 @@ repositories:
   ign_tools       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-tools.git',         version: '22d5bada1e36' }
   ign_gui         : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: 'drake-ign-math' }
   ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: '2d046d5daa73' }
-  ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: '043b69f902f6' }
+  ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: '76797344db13' }
   ign_cmake       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-cmake.git',         version: 'c4a7896c4622' }
   drake           : { type: 'git', url: 'https://github.com/RobotLocomotion/drake.git',                 version: '14596fbf433f3c8ca15bf51832acdc184088a2df' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'master' }

--- a/setup.bash
+++ b/setup.bash
@@ -53,6 +53,10 @@ export DELPHYNE_AGENT_PLUGIN_PATH=$INSTALL_PREFIX/lib/delphyne/agents
 add_if_not_in_var DELPHYNE_PACKAGE_PATH $INSTALL_PREFIX/share/drake/automotive/models
 add_if_not_in_var LD_LIBRARY_PATH $INSTALL_PREFIX/lib
 add_if_not_in_var PATH $INSTALL_PREFIX/bin
+
+# Needed for helping Ignition Msgs to find .desc files
+add_if_not_in_var IGN_DESCRIPTOR_DIR $INSTALL_PREFIX/include/delphyne0/delphyne/protobuf
+
 # Need to clean up how we install python modules so we don't need this tangle
 add_if_not_in_var PYTHONPATH $INSTALL_PREFIX/lib/python2.7/site-packages
 add_if_not_in_var PYTHONPATH $INSTALL_PREFIX/lib


### PR DESCRIPTION
It needs [PR # 394](https://github.com/ToyotaResearchInstitute/delphyne/pull/394) from Delphyne.

It updates Ignition Msgs for receiving the last version of the factory class than can use Protobuf descriptor information for creating messages. Also, points the `IGN_DESCRIPTOR_DIR` environment variable to the directory where our `.desc` files are installed.

It fixes issue [# 359](https://github.com/ToyotaResearchInstitute/delphyne/issues/359).

You can see how the topic viewer displays our custom `/agents/0/state` topic.

![topicviewer](https://user-images.githubusercontent.com/1440739/39769753-ed38b6e0-52a1-11e8-8a3d-e7034ec783fd.png)
