### PR TITLE
[repos] bump drake to get agent trajectories

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -6,6 +6,6 @@ repositories:
   ign_rendering   : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: '2d046d5daa73' }
   ign_msgs        : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: '76797344db13' }
   ign_cmake       : { type: 'hg', url:  'https://bitbucket.org/ignitionrobotics/ign-cmake.git',         version: 'c4a7896c4622' }
-  drake           : { type: 'git', url: 'https://github.com/RobotLocomotion/drake.git',                 version: '14596fbf433f3c8ca15bf51832acdc184088a2df' }
+  drake           : { type: 'git', url: 'https://github.com/RobotLocomotion/drake.git',                 version: 'b6584590a2969184174882c0d7c0c69ca8161bca' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'master' }
   delphyne_gui    : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',      version: 'master' }


### PR DESCRIPTION
Tested, no problems that I found for delphyne.

This gives us access to the new `AgentTrajectory` type and it's makers (replaces the old Curve types).
