### PR TITLE
Update libqwt dependency

### DIFF
--- a/tools/install_prereqs.sh
+++ b/tools/install_prereqs.sh
@@ -50,7 +50,7 @@ libogre-1.9-dev
 libprotobuf-dev
 libprotoc-dev
 libqt5multimedia5
-libqwt-dev
+libqwt-qt5-dev
 libtinyxml2-dev
 libzmq3-dev
 mercurial


### PR DESCRIPTION
We were using `libqwt-dev` instead of `libqwt-qt5-dev`. This was causing the installation of some qt4 and qt5 dependencies. Also, we were linking against qt4 and qt5 libraries.

See issue #105 for more details.