### PR TITLE
Remove custom style for buttons

### DIFF
--- a/visualizer/layoutWithTeleop.config
+++ b/visualizer/layoutWithTeleop.config
@@ -61,10 +61,9 @@
     /* ---------------------------- */
     /*           Buttons            */
     /* ---------------------------- */
-
     QPushButton#collapsibleButton
     {
-      margin: 0px;
+      padding: 8px;
     }
   </stylesheet>
   <menus>


### PR DESCRIPTION
See issue #75.

![kde_delphyne](https://user-images.githubusercontent.com/1440739/40812953-5ae0042a-64ed-11e8-8dd6-05ab4a4aa5fa.png)

There's one extra pull request ([#113](https://bitbucket.org/ignitionrobotics/ign-gui/pull-requests/113)) under review in Ignition GUI that will use the system style when highlighting elements over the topic viewer.