### PR TITLE
Remove the installation of libignition-cmake-dev using apt

### DIFF
--- a/tools/install_prereqs.sh
+++ b/tools/install_prereqs.sh
@@ -45,7 +45,6 @@ libfreeimage-dev
 libglew-dev
 libgts-dev
 libicu-dev
-libignition-cmake-dev
 libogre-1.9-dev
 libprotobuf-dev
 libprotoc-dev


### PR DESCRIPTION
This is not needed anymore as we're cloning Ignition CMake directly inside our workspace.