### PR TITLE
[infra] drop the python path to the lib dir

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -66,6 +66,3 @@ add_if_not_in_var PATH $INSTALL_PREFIX/bin
 
 # Path to python modules
 add_if_not_in_var PYTHONPATH $INSTALL_PREFIX/lib/python2.7/site-packages
-
-# Path to python bindings
-add_if_not_in_var PYTHONPATH $INSTALL_PREFIX/lib


### PR DESCRIPTION
The python bindings now reside alongside the other modules in
the delphyne package, so no additional python path setting is
necessary.