### PR TITLE
Modifies visualizer layout to make model name and pose visible

### DIFF
--- a/visualizer/layoutWithTeleop.config
+++ b/visualizer/layoutWithTeleop.config
@@ -145,8 +145,6 @@
   <hide>model::link::sensor</hide>
   <hide>model::link::visual</hide>
   <hide>model::model</hide>
-  <hide>model::name</hide>
-  <hide>model::pose</hide>
   <hide>model::scale</hide>
   <hide>model::self_collide</hide>
   <hide>model::visual</hide>


### PR DESCRIPTION
Connected to ToyotaResearchInstitute/delphyne#423. This pull requests makes minor modifications to the visualizer Qt layouts to make a couple (literally, two) fields visible in the SceneTree widget.