### PR TITLE
Replaced drake asserts with delphyne's own

### DIFF
--- a/visualizer/CMakeLists.txt
+++ b/visualizer/CMakeLists.txt
@@ -3,12 +3,14 @@ include (${project_cmake_dir}/Utils.cmake)
 # ----------------------------------------
 # MaliputMesh library.
 set(maliput_mesh MaliputMesh)
+
 add_library(${maliput_mesh}
   maliput_mesh_builder.cc)
+
 target_link_libraries(${maliput_mesh}
-  delphyne::assert
   ${drake_LIBRARIES}
-  ${IGNITION-COMMON_LIBRARIES})
+  ${IGNITION-COMMON_LIBRARIES}
+  delphyne::public_headers)
 
 install(TARGETS ${maliput_mesh} DESTINATION
   ${LIB_INSTALL_DIR} COMPONENT shlib)

--- a/visualizer/maliput_mesh.hh
+++ b/visualizer/maliput_mesh.hh
@@ -17,7 +17,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <delphyne/assert.h>
+#include <delphyne/macros.h>
 
 #include <drake/automotive/maliput/api/branch_point.h>
 #include <drake/automotive/maliput/api/junction.h>

--- a/visualizer/maliput_mesh_builder.cc
+++ b/visualizer/maliput_mesh_builder.cc
@@ -14,7 +14,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <delphyne/assert.h>
+#include <delphyne/macros.h>
 
 #include <drake/automotive/maliput/api/branch_point.h>
 #include <drake/automotive/maliput/api/junction.h>


### PR DESCRIPTION
Fixes item 15 from list in [delphyne's #296](https://github.com/ToyotaResearchInstitute/delphyne/issues/296):  "delphyne-gui should use delphyne's system.h"

- Replaces drake's assert by delphyne's own

This PR goes hand-by-hand with [delphyne's #442](https://github.com/ToyotaResearchInstitute/delphyne/pull/442)