### PR TITLE
Provides text labels to the road visualizer.

### DIFF
--- a/visualizer/maliput_viewer_model.hh
+++ b/visualizer/maliput_viewer_model.hh
@@ -34,6 +34,28 @@ class MaliputMesh {
   std::unique_ptr<drake::maliput::mesh::Material> material{};
 };
 
+/// \brief Holds the information to build a label.
+class MaliputLabel {
+ public:
+  /// \brief Holds the visualization status.
+  bool visible{false};
+
+  /// \brief Holds the mesh status.
+  bool enabled{false};
+
+  /// \brief Text to show by the label.
+  std::string text{};
+
+  /// \brief Position of the label.
+  ignition::math::Vector3d position{};
+};
+
+/// \brief Type of label based on road entities.
+enum class MaliputLabelType {
+  kLane,         ///< A lane label.
+  kBranchPoint,  ///< A branch point label.
+};
+
 /// \brief Model of the plugin.
 ///
 /// Holds the information, as a map of meshes and materials.
@@ -57,6 +79,10 @@ class MaliputViewerModel {
   /// \return The map of meshes.
   const std::map<std::string, std::unique_ptr<MaliputMesh>>& Meshes() const;
 
+  /// \brief Getter of the map of labels.
+  /// \return The map of labels.
+  const std::map<MaliputLabelType, std::vector<MaliputLabel>>& Labels() const;
+
   /// \brief Modifies the visualization state of @p key mesh.
   /// \param[in] _key The name of the mesh.
   /// \param[in] _newVisualState The new visualization status of the mesh.
@@ -71,11 +97,18 @@ class MaliputViewerModel {
   void ConvertMeshes(
     const std::map<std::string, drake::maliput::mesh::GeoMesh>& _geoMeshes);
 
+  /// \brief Populates this->labels map with this->roadGeometry lane and branch
+  ///        point IDs.
+  void GenerateLabels();
+
   /// \brief Maliput RoadGeometry pointer.
   std::unique_ptr<const drake::maliput::api::RoadGeometry> roadGeometry;
 
   /// \brief Map of meshes to hold all the ignition meshes.
   std::map<std::string, std::unique_ptr<MaliputMesh>> maliputMeshes;
+
+  /// \brief Map of labels.
+  std::map<MaliputLabelType, std::vector<MaliputLabel>> labels;
 };
 
 }

--- a/visualizer/maliput_viewer_widget.cc
+++ b/visualizer/maliput_viewer_widget.cc
@@ -58,6 +58,7 @@ void MaliputViewerWidget::paintEvent(QPaintEvent* _e) {
   if (!first_run_) {
     first_run_ = true;
     this->renderWidget->RenderRoadMeshes(this->model->Meshes());
+    this->renderWidget->RenderLabels(this->model->Labels());
   }
 
   this->renderWidget->paintEvent(_e);

--- a/visualizer/render_maliput_widget.hh
+++ b/visualizer/render_maliput_widget.hh
@@ -46,10 +46,16 @@ class RenderMaliputWidget : public QWidget {
   // one each time. That API is available on this commit:
   // https://bitbucket.org/ignitionrobotics/ign-rendering/commits/5accdc88afc557afc03c811d9e892ccb7f99951a
   // ign-cmake dependency should be switched to 'Components' branch. So, once
-  // eveything is stable on default or in a release branch, we should modify
+  // everything is stable on default or in a release branch, we should modify
   // this method to properly set the transparency.
   void RenderRoadMeshes(
     const std::map<std::string, std::unique_ptr<MaliputMesh>>& _maliputMeshes);
+
+  /// \brief Builds visuals for each label inside @p _labels whose state
+  /// is State::kOn.
+  /// \param[in] _labels A map of labels to render.
+  void RenderLabels(
+    const std::map<MaliputLabelType, std::vector<MaliputLabel>>& _labels);
 
   /// \brief Overridden method to receive Qt paint event.
   /// \param[in] _e The event that happened.
@@ -128,6 +134,16 @@ class RenderMaliputWidget : public QWidget {
   /// \brief Fills a material to be transparent.
   /// \param[in] _material Material to be transparent.
   void CreateTransparentMaterial(
+    ignition::rendering::MaterialPtr& _material) const;
+
+  /// \brief Fills a material for a lane label.
+  /// \param[in] _material Material to be filled.
+  void CreateLaneLabelMaterial(
+    ignition::rendering::MaterialPtr& _material) const;
+
+  /// \brief Fills a material for a branch point label.
+  /// \param[in] _material Material to be filled.
+  void CreateBranchPointLabelMaterial(
     ignition::rendering::MaterialPtr& _material) const;
 
   /// \brief Creates a bare visual and adds it as a child of the scene's root


### PR DESCRIPTION
This PR is a first approach to provide text labels to the road visualizer. See maliput/maliput_viz#14 for the scope of this first approach.

Taking @maddog-tri comments, only branch points and lanes are covered. Lane labels are set at the middle of the lane and are yellow, while branch point labels are over one of the lane-ends and are green. 

No toggling support is provided yet. Next PR will come with it.

A picture of what you should see is left below:

![labels](https://user-images.githubusercontent.com/3825465/42291755-1adc083e-7fa4-11e8-954a-3779f6f28db5.png)

... after running:

```
maliput_viewer.sh --yaml_file=install/share/delphyne/roads/double_ring.yaml
```