### PR TITLE
Fix the IGN_DESCRIPTOR_PATH in setup.bash

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -56,7 +56,7 @@ export DELPHYNE_RESOURCE_ROOT=${INSTALL_PREFIX}/share/delphyne
 add_if_not_in_var DELPHYNE_PACKAGE_PATH $INSTALL_PREFIX/share/drake/automotive/models
 
 # Path to descriptors of custom ignition messages (nec. for topic introspection)
-add_if_not_in_var IGN_DESCRIPTOR_PATH $INSTALL_PREFIX/include/delphyne0/delphyne/protobuf
+add_if_not_in_var IGN_DESCRIPTOR_PATH $INSTALL_PREFIX/include/delphyne/protobuf
 
 # Path to c++ libraries
 add_if_not_in_var LD_LIBRARY_PATH $INSTALL_PREFIX/lib


### PR DESCRIPTION
Fixes the path `IGN_DESCRIPTOR_PATH`, that changed in delphyne recently but wasn't properly reflected here.
This allow us to benefit from the changes originally introduced in #99, allowing the `Topic Viewer` to introspect non-ignition messages. 