### PR TITLE
Kick-off the replayer process.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ else (build_errors)
 
   set(TEST_TYPE "UNIT")
   add_subdirectory(visualizer)
+  add_subdirectory(replayer)
   add_subdirectory(test)
 
   ########################################

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -107,6 +107,16 @@ if (NOT WIN32)
     include_directories(${IGNITION-TRANSPORT_INCLUDE_DIRS})
     link_directories(${IGNITION-TRANSPORT_LIBRARY_DIRS})
   endif()
+  # Find ignition transport LOG
+  find_package(ignition-transport5-log REQUIRED)
+  if (NOT ignition-transport5-log_FOUND)
+    message(STATUS "Looking for ignition-transport5-log-config.cmake - not found")
+    BUILD_ERROR ("Missing: Ignition transport5-log library.")
+  else()
+    message(STATUS "Looking for ignition-transport5-log-config.cmake - found")
+    include_directories(${IGNITION-TRANSPORT-LOG_INCLUDE_DIRS})
+    link_directories(${IGNITION-TRANSPORT-LOG_LIBRARY_DIRS})
+  endif()
 endif()
 
 ########################################

--- a/replayer/CMakeLists.txt
+++ b/replayer/CMakeLists.txt
@@ -1,0 +1,13 @@
+include (${project_cmake_dir}/Utils.cmake)
+
+# Replayer
+add_executable(replayer
+  replayer.cc
+)
+
+target_link_libraries(replayer
+  ${IGNITION-COMMON_LIBRARIES}
+  ${IGNITION-TRANSPORT_LIBRARIES}
+)
+
+install (TARGETS replayer DESTINATION ${BIN_INSTALL_DIR})

--- a/replayer/replayer.cc
+++ b/replayer/replayer.cc
@@ -1,0 +1,49 @@
+// Copyright 2017 Toyota Research Institute
+
+#include <cstdint>
+#include <iostream>
+#include <regex>
+#include <ignition/transport/log/Playback.hh>
+#include <ignition/common/Console.hh>
+
+//////////////////////////////////////////////////
+int main(int argc, char *argv[])
+{
+  ignition::common::Console::SetVerbosity(3);
+  if (argc != 2)
+  {
+    ignerr << "No logfile was provided.\n"
+           << "Usage: " << argv[0] << " <path-to-logfile.db>" << std::endl;
+    return 1;
+  }
+
+  // Creates a Playback with the logfile passed via argument.
+  ignition::transport::log::Playback player(argv[1]);
+
+  // Playbacks all topics.
+  const int64_t addTopicResult = player.AddTopic(std::regex(".*"));
+  if (addTopicResult == 0)
+  {
+    ignerr << "No topics to play back" << std::endl;
+    return 1;
+  }
+  else if (addTopicResult < 0)
+  {
+    ignerr << "Failed to advertise topics: " << addTopicResult << std::endl;
+    return 1;
+  }
+
+  // Begins playback.
+  const auto handle = player.Start();
+  if (!handle)
+  {
+    ignerr << "Failed to start playback" << std::endl;
+    return 1;
+  }
+
+  // Waits until the player stops on its own.
+  ignmsg << "Playing all messages in the log file." << std::endl;
+  handle->WaitUntilFinished();
+
+  return 0;
+}


### PR DESCRIPTION
Addresses the first item from the task list in [delphyne's #493](https://github.com/ToyotaResearchInstitute/delphyne/issues/493).
- Implements a very simple logging replayer executable.
- It takes a logfile path as an argument and then republishes all the messages found via ignition transport.