### PR TITLE
Added missing libsqlite3-dev to the dependencies list

### DIFF
--- a/tools/install_prereqs.sh
+++ b/tools/install_prereqs.sh
@@ -46,6 +46,7 @@ libglew-dev
 libgts-dev
 libicu-dev
 libogre-1.9-dev
+libsqlite3-dev
 libprotobuf-dev
 libprotoc-dev
 libqt5multimedia5


### PR DESCRIPTION
Adds a missing dependency that was recently added to ignition-transport: libsqlite3-dev