### PR TITLE
Adds libzip as a Delphyne dependency

### DIFF
--- a/tools/install_prereqs.sh
+++ b/tools/install_prereqs.sh
@@ -52,6 +52,7 @@ libprotoc-dev
 libqt5multimedia5
 libqwt-qt5-dev
 libtinyxml2-dev
+libzip-dev
 libzmq3-dev
 mercurial
 mesa-utils


### PR DESCRIPTION
Necessary after https://github.com/ToyotaResearchInstitute/delphyne/pull/512.