### PR TITLE
Mesh lookup redirection to support simulation replays

### DIFF
--- a/visualizer/CMakeLists.txt
+++ b/visualizer/CMakeLists.txt
@@ -73,7 +73,8 @@ target_link_libraries(${render_widget}
   ${IGNITION-TRANSPORT_LIBRARIES}
   ${Qt5Core_LIBRARIES}
   ${Qt5Widgets_LIBRARIES}
-  delphyne::protobuf_messages)
+  delphyne::protobuf_messages
+  delphyne::utility)
 
 install(TARGETS ${render_widget} DESTINATION ${LIB_INSTALL_DIR} COMPONENT shlib)
 
@@ -113,6 +114,7 @@ target_link_libraries(visualizer
   ${Qt5Core_LIBRARIES}
   ${Qt5Widgets_LIBRARIES}
   ${global_attributes}
+  delphyne::utility
 )
 
 install (TARGETS visualizer DESTINATION ${BIN_INSTALL_DIR})

--- a/visualizer/render_widget.cc
+++ b/visualizer/render_widget.cc
@@ -8,6 +8,8 @@
 #include <utility>
 #include <tinyxml2.h>
 
+#include <delphyne/utility/package.h>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/MeshManager.hh>
 #include <ignition/common/PluginMacros.hh>
@@ -33,6 +35,7 @@
 #include <ignition/rendering/Scene.hh>
 
 #include "render_widget.hh"
+
 
 Q_DECLARE_METATYPE(ignition::msgs::Model_V)
 Q_DECLARE_METATYPE(ignition::msgs::Scene)
@@ -85,31 +88,6 @@ static void setPoseFromMessage(const ignition::msgs::Link& _link,
 }
 
 /////////////////////////////////////////////////
-std::string RenderWidget::FindFile(const std::string& _path) const {
-  std::string res = "";
-  // Case 1: Absolute path. E.g,: "/tmp/my_mesh.dae"
-  if (ignition::common::StartsWith(_path, "/")) {
-    if (ignition::common::exists(_path)) {
-      res = _path;
-    }
-    return res;
-  }
-
-  auto index = _path.find("://");
-  std::string path = _path;
-
-  // Case 2: Contains a prefix. E.g.: "package://meshes/my_mesh.dae"
-  if (index != std::string::npos) {
-    // Remove the prefix.
-    path = _path.substr(index + 3, _path.size() - index - 3);
-  }
-
-  // Case 3: Relative path. E.g.: "meshes/my_mesh.dae"
-  return ignition::common::SystemPaths::LocateLocalFile(path,
-                                                        this->packagePaths);
-}
-
-/////////////////////////////////////////////////
 RenderWidget::RenderWidget(QWidget* parent)
     : Plugin(), initializedScene(false), engine(nullptr) {
   qRegisterMetaType<ignition::msgs::Scene>();
@@ -140,14 +118,6 @@ RenderWidget::RenderWidget(QWidget* parent)
       SLOT(SetInitialScene(const ignition::msgs::Scene&)));
   QObject::connect(this, SIGNAL(NewDraw(const ignition::msgs::Model_V&)), this,
                    SLOT(UpdateScene(const ignition::msgs::Model_V&)));
-
-  auto paths =
-      ignition::common::SystemPaths::PathsFromEnv("DELPHYNE_PACKAGE_PATH");
-  if (paths.empty()) {
-    ignerr << "DELPHYNE_PACKAGE_PATH environment variable is not set"
-           << std::endl;
-  }
-  std::copy(paths.begin(), paths.end(), std::back_inserter(this->packagePaths));
 
   // Setting up a unique-named service name
   // i.e: Scene_8493201843;
@@ -490,12 +460,17 @@ ignition::rendering::VisualPtr RenderWidget::RenderMesh(
   }
 
   auto filename = _vis.geometry().mesh().filename();
+  delphyne::utility::PackageManager* package_manager =
+      delphyne::utility::PackageManager::Instance();
+  const utility::Package& package_in_use =
+      package_manager->package_in_use();
   ignition::rendering::MeshDescriptor descriptor;
-  descriptor.meshName = this->FindFile(filename);
-  if (descriptor.meshName.empty()) {
+  ignition::common::URI mesh_uri = package_in_use.Resolve(filename);
+  if (!mesh_uri.Valid()) {
     ignerr << "Unable to locate mesh [" << filename << "]" << std::endl;
     return nullptr;
   }
+  descriptor.meshName = "/" + mesh_uri.Path().Str();
   ignition::common::MeshManager* meshManager =
       ignition::common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);

--- a/visualizer/render_widget.hh
+++ b/visualizer/render_widget.hh
@@ -221,19 +221,6 @@ class RenderWidget : public ignition::gui::Plugin {
   /// \brief Render the origin reference frame.
   void RenderOrigin();
 
-  /// \brief Find a file by name.
-  /// In the case of an absolute path:
-  ///   The function will check if the path exists.
-  /// In the case of a relative path:
-  ///   The function will search for the path in all the directories
-  ///   specified in the environment variable DELPHYNE_PACKAGE_PATH.
-  /// In the case of a path with a prefix (e.g.: package://drake/my_mesh.dae):
-  ///   The prefix ("package://") is removed and the remaining path is
-  /// searched as if a relative path was specified.
-  /// \param[in] _path The path of the file.
-  /// \return The full path to the file or an empty string if not found.
-  std::string FindFile(const std::string& _path) const;
-
   /// \brief The frequency at which we'll do an update on the widget.
   const int kUpdateTimeFrequency = static_cast<int>(std::round(1000.0 / 60.0));
 
@@ -260,11 +247,6 @@ class RenderWidget : public ignition::gui::Plugin {
 
   /// \brief Controls the view of the scene.
   std::unique_ptr<OrbitViewControl> orbitViewControl;
-
-  /// \brief List of paths that can contain resources (e.g.: meshes).
-  /// The content of this variable is populated with the value of the
-  /// DELPHYNE_PACKAGE_PATH environment variable.
-  std::vector<std::string> packagePaths;
 
   /// \brief This the data structure that stores the pointers to all visuals.
   /// The key is the model Id.

--- a/visualizer/visualizer.cc
+++ b/visualizer/visualizer.cc
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include <delphyne/utility/package.h>
+
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/Util.hh>
@@ -47,6 +49,17 @@ int main(int argc, const char* argv[]) {
     delphyne::gui::GlobalAttributes::HasArgument("layout") ?
       delphyne::gui::GlobalAttributes::GetArgument("layout") :
       initialConfigFile;
+
+  delphyne::utility::PackageManager* package_manager =
+      delphyne::utility::PackageManager::Instance();
+  if (delphyne::gui::GlobalAttributes::HasArgument("package")) {
+    package_manager->Use(
+        std::make_unique<delphyne::utility::BundledPackage>(
+            delphyne::gui::GlobalAttributes::GetArgument("package")));
+  } else {
+    package_manager->Use(
+        std::make_unique<delphyne::utility::SystemPackage>());
+  }
 
   Q_INIT_RESOURCE(resources);
 


### PR DESCRIPTION
This pull requests enables resource lookup redirection at the visualizer, specifically to pull meshes from logs and not from the system installation.

Depends on https://github.com/ToyotaResearchInstitute/delphyne/pull/512. Depends on #146.