### PR TITLE
Disable shadow rendering

### DIFF
--- a/visualizer/layout_with_render_only.config
+++ b/visualizer/layout_with_render_only.config
@@ -23,4 +23,5 @@
 
 <plugin filename="RenderWidget">
   <has_titlebar>false</has_titlebar>
+  <cast_shadows>false</cast_shadows>
 </plugin>

--- a/visualizer/render_widget.cc
+++ b/visualizer/render_widget.cc
@@ -161,6 +161,15 @@ void RenderWidget::LoadConfig(const tinyxml2::XMLElement* _pluginElem) {
     return;
   }
 
+  // Configure if we need to cast shadows.
+  bool castShadows = kCastShadowsByDefault;
+
+  if (auto castShadowsElem = _pluginElem->FirstChildElement("cast_shadows")) {
+    castShadowsElem->QueryBoolText(&castShadows);
+  }
+
+  this->mainDirectionalLight->SetCastShadows(castShadows);
+
   // Load the user camera options.
   auto userCameraXML = _pluginElem->FirstChildElement("camera");
   while (userCameraXML) {
@@ -670,15 +679,16 @@ void RenderWidget::CreateRenderWindow() {
     ignerr << "Failed to find the root visual" << std::endl;
     return;
   }
-  auto directionalLight = this->scene->CreateDirectionalLight();
-  if (!directionalLight) {
+  this->mainDirectionalLight = this->scene->CreateDirectionalLight();
+  if (!this->mainDirectionalLight) {
     ignerr << "Failed to create a directional light" << std::endl;
     return;
   }
-  directionalLight->SetDirection(-0.5, -0.5, -1);
-  directionalLight->SetDiffuseColor(0.9, 0.9, 0.9);
-  directionalLight->SetSpecularColor(0.9, 0.9, 0.9);
-  root->AddChild(directionalLight);
+  this->mainDirectionalLight->SetDirection(-0.5, -0.5, -1);
+  this->mainDirectionalLight->SetDiffuseColor(0.9, 0.9, 0.9);
+  this->mainDirectionalLight->SetSpecularColor(0.9, 0.9, 0.9);
+  this->mainDirectionalLight->SetCastShadows(kCastShadowsByDefault);
+  root->AddChild(this->mainDirectionalLight);
 
   // create user camera
   this->camera = this->scene->CreateCamera("user_camera");

--- a/visualizer/render_widget.hh
+++ b/visualizer/render_widget.hh
@@ -233,6 +233,9 @@ class RenderWidget : public ignition::gui::Plugin {
   /// \brief Pointer to the camera created by this class.
   ignition::rendering::CameraPtr camera;
 
+  /// \brief Pointer to the main directional light created by this class.
+  ignition::rendering::DirectionalLightPtr mainDirectionalLight;
+
   /// \brief A transport node.
   ignition::transport::Node node;
 
@@ -260,6 +263,9 @@ class RenderWidget : public ignition::gui::Plugin {
 
   /// \brief Store all the user settings.
   UserSettings userSettings;
+
+  /// \brief Are we casting shadows by default?
+  bool kCastShadowsByDefault{true};
 };
 }
 }


### PR DESCRIPTION
As part of the performance improvements @nkoenig noted that shadows may be taking an important amount of the rendering time. Testing a dragway with 50 cars FPS goes from 25 to 38 when removing shadows, so I think it is worth the change.