### PR TITLE
Removes extra triangle creation in meshes

### DIFF
--- a/visualizer/maliput_mesh_builder.cc
+++ b/visualizer/maliput_mesh_builder.cc
@@ -894,19 +894,11 @@ std::unique_ptr<ignition::common::Mesh> Convert(const std::string& name,
     sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[0]));
     sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[1]));
     sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[2]));
-
-    sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[2]));
-    sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[1]));
-    sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[0]));
     // Includes the remaining triangle.
     if (index_face.vertices().size() == 4) {
       sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[2]));
       sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[3]));
       sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[0]));
-
-      sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[0]));
-      sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[3]));
-      sub_mesh->AddIndex(std::get<1>(ordered_vertices_indices[2]));
     }
   }
 


### PR DESCRIPTION
This PR improves in a 50% the efficiency as we were creating two triangles with the opposite rotation order to visualize the mesh from both sides. As new examples will include bigger cities, where more cars will be needed, any improvement to the mesh generation will provide a better user experience.

A picture of the road introduced in #152 from below with current in-master code:

![before](https://user-images.githubusercontent.com/3825465/43977431-8bf1f69a-9cba-11e8-90c1-f45a7107732f.png)

And one picture with code form this branch:

![after](https://user-images.githubusercontent.com/3825465/43977433-90d80136-9cba-11e8-8d4d-e7350a041aec.png)
