### PR TITLE
Add RTF display to Displays widget

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -6,7 +6,7 @@ repositories:
   ign_common      : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-common.git',        version: '9aa7c3b9da1b' }
   ign_msgs        : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-msgs.git',          version: 'ef3a5f00b764' }
   ign_transport   : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-transport.git',     version: '3d157ef7e32e' }
-  ign_rendering   : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: '13c229e9fd45' }
-  ign_gui         : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: 'dbd168a5bf38' }
+  ign_rendering   : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: '2470a8191729' }
+  ign_gui         : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: 'dhood_display_plugins_rtf_overlay' }
   delphyne        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',          version: 'master' }
   delphyne_gui    : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',      version: 'master' }

--- a/visualizer/layout_with_teleop.config
+++ b/visualizer/layout_with_teleop.config
@@ -164,6 +164,7 @@
 
 <plugin filename="Displays">
   <displays>
+    <display type="RealtimeFactorDisplay" />
     <display type="GridDisplay">
       <cell_count>50</cell_count>
       <vertical_cell_count>0</vertical_cell_count>


### PR DESCRIPTION
Preview of the RTF display plugin. Size, colour and padding can be configured.

Demo gif with `delphyne-gazoo`:

![realtimefactordisplay_delphyne_colour](https://user-images.githubusercontent.com/5618076/44559178-17246d00-a6fd-11e8-8a3a-c9730f07091a.gif)

This PR is not proposed for merge yet because [one of the dependency PRs](https://bitbucket.org/ignitionrobotics/ign-gui/pull-requests/150) is still in review.

Note: The south-east corner was mentioned as a location for the RTF. Not sure how fixed of a requirement that is; the reason the text is left-aligned and anchored to the bottom left corner is because right-alignment of text is not currently implemented in ignition-rendering.

Note: This PR builds on top of https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/151 and targets the branch used for that PR to minimise the diff displayed. It can be retargeted to master when that PR's merged.