### PR TITLE
Bring latest drake

### DIFF
--- a/delphyne.repos
+++ b/delphyne.repos
@@ -1,5 +1,5 @@
 repositories:
-  drake           : { type: 'git', url: 'https://github.com/RobotLocomotion/drake.git',                 version: '26deccd2bc66cddb5ea5d9da9732b70437cb6ab6' }
+  drake           : { type: 'git', url: 'https://github.com/RobotLocomotion/drake.git',                 version: '97db14bd4d14c9ca1329e81c007ee09645a18e69' }
   ign_cmake       : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-cmake.git',         version: '9b5a8d7e1a58' }
   ign_tools       : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-tools.git',         version: 'b4ea8a5347db' }
   ign_math        : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-math.git',          version: '7c83076419cf' }


### PR DESCRIPTION
This PR just brings Drake to the latest commit. We can then go ahead and re-test https://github.com/ToyotaResearchInstitute/delphyne/pull/574 (which I did locally and works ok)