### PR TITLE
Provide argument to visualizer to use line buffering when it is a child process

### DIFF
--- a/delphyne-gui/python/utilities.py
+++ b/delphyne-gui/python/utilities.py
@@ -67,6 +67,8 @@ def launch_visualizer(launcher_manager, layout_filename=None,
             os.path.join("layouts", layout_filename)
         )
         ign_visualizer_args.append(layout_key + layout_path)
+    # Force line buffering for child process.
+    ign_visualizer_args.append("--use-line-buffer=yes")
     if plugin_injection:
         ign_visualizer_args.append("--inject-plugin=" + plugin_injection)
     if bundle_path:

--- a/delphyne-gui/visualizer/visualizer.cc
+++ b/delphyne-gui/visualizer/visualizer.cc
@@ -47,6 +47,19 @@ int main(int argc, const char* argv[]) {
     delphyne::gui::GlobalAttributes::ParseArguments(argc - 1, &(argv[1]));
   }
 
+  // If we run the visualizer as a child process (like a demo written in
+  // python), we need to ensure that it's not using a block buffer
+  // to display everything that goes to the stdout in realtime. 
+  if (delphyne::gui::GlobalAttributes::HasArgument("use-line-buffer"))
+  {
+    std::string use_line_buffer_arg =
+      delphyne::gui::GlobalAttributes::GetArgument("use-line-buffer");
+    if (use_line_buffer_arg == "yes")
+    {
+      setlinebuf(stdout);
+    }
+  }
+
   // Parse custom config file from args.
   delphyne::utility::PackageManager* package_manager =
       delphyne::utility::PackageManager::Instance();


### PR DESCRIPTION
Fixes one of the bullets of issue #212 and also it shows debug messages properly

> Print the default saved configuration to stdout so we know where it is saved to