### PR TITLE
Use behaviour trees in keyop demo

### DIFF
--- a/delphyne-demos/demos/keyop.py
+++ b/delphyne-demos/demos/keyop.py
@@ -88,7 +88,7 @@ def demo_callback(behaviour_tree, keyboard_handler, time_step_seconds):
                 behaviour_tree.runner.pause_simulation()
                 print("Simulation is now paused.")
         elif key == 'q':
-            behaviour_tree.interrupt_tick_tocking = True
+            behaviour_tree.interrupt()
             print("Quitting simulation.")
         elif key == 's':
             if behaviour_tree.runner.is_simulation_paused():


### PR DESCRIPTION
Something to notice is that the simulation blocks in a while loop when it's paused, so the tree execution stops at `self.runner.run_sync_for` in `trees.py` living in delphyne's repository. There's no way for the moment to use a behaviour or a pre/post tick handler to unpause/step a simulation.