### PR TITLE
Move mobil_perf demo to pytrees

### DIFF
--- a/delphyne-demos/demos/mobil_perf.py
+++ b/delphyne-demos/demos/mobil_perf.py
@@ -64,7 +64,7 @@ def curved_lanes(args):
                     R0 - R * math.cos(theta),  # m
                     theta  # rads
                 ),
-                direction_of_travel=0,
+                direction_of_travel=False,
                 speed=1.,  # m/s
             )
         )
@@ -110,7 +110,7 @@ def straight_lanes(args):
                     4. * (i % 3),  # m
                     0.  # rads
                 ),
-                direction_of_travel=0,
+                direction_of_travel=False,
                 speed=1.,  # m/s
             )
         )
@@ -158,7 +158,7 @@ def dragway(args):
                     -5.5 + 3.7 * (i % 4),  # m
                      0.  # rads
                 ),
-                direction_of_travel=0,
+                direction_of_travel=False,
                 speed=1.,  # m/s
             )
         )


### PR DESCRIPTION
A first draft of the pytree port.

Things I think we should consider:
-
- Running the pytree demo and the regular demo side by side reveals the cars start out seemingly correct (for 1-2 simulation seconds) and then veer off performing figure 8's - not sure if that's an artifact of a bug within this code or a resultant behavior from something upstream - I can provide video examples tomorrow but am leaving for the day now
- Is this usage of `lane_provider.random_lane` appropriate for car placement?  Is it a good equivalent to the previous behaviour?