### PR TITLE
Remove rules namespace for classes that belong to regions.h

### DIFF
--- a/delphyne-gui/visualizer/maliput_viewer_model.cc
+++ b/delphyne-gui/visualizer/maliput_viewer_model.cc
@@ -68,17 +68,17 @@ std::ostream& operator<<(std::ostream& out, const maliput::api::rules::RightOfWa
 }
 
 // Serializes `s_range` into `out`.
-std::ostream& operator<<(std::ostream& out, const maliput::api::rules::SRange& s_range) {
+std::ostream& operator<<(std::ostream& out, const maliput::api::SRange& s_range) {
   return out << "[" << s_range.s0() << ", " << s_range.s1() << "]";
 }
 
 // Serializes `lane_s_range` into `out`.
-std::ostream& operator<<(std::ostream& out, const maliput::api::rules::LaneSRange& lane_s_range) {
+std::ostream& operator<<(std::ostream& out, const maliput::api::LaneSRange& lane_s_range) {
   return out << "Range(lane_id: " << lane_s_range.lane_id().string() << ", s_range:" << lane_s_range.s_range() << ")";
 }
 
 // Serializes `lane_s_route` into `out`.
-std::ostream& operator<<(std::ostream& out, const maliput::api::rules::LaneSRoute& lane_s_route) {
+std::ostream& operator<<(std::ostream& out, const maliput::api::LaneSRoute& lane_s_route) {
   out << "Route(ranges: [";
   for (const auto& range : lane_s_route.ranges()) {
     out << range << ", ";
@@ -218,7 +218,7 @@ void RoadNetworkQuery::GetDirectionUsage(const maliput::api::LaneId& lane_id) {
 }
 
 /////////////////////////////////////////////////
-void RoadNetworkQuery::GetRightOfWay(const maliput::api::rules::LaneSRange& lane_s_range) {
+void RoadNetworkQuery::GetRightOfWay(const maliput::api::LaneSRange& lane_s_range) {
   const maliput::api::rules::RoadRulebook::QueryResults results = rn_->rulebook()->FindRules({lane_s_range}, 0.);
   const maliput::api::rules::RuleStateProvider* rule_state_provider = rn_->rule_state_provider();
   (*out_) << "Right of way for " << lane_s_range << ":" << std::endl;
@@ -293,9 +293,9 @@ maliput::api::rules::RoadRulebook::QueryResults RoadNetworkQuery::FindRulesFor(c
     return maliput::api::rules::RoadRulebook::QueryResults();
   }
 
-  const maliput::api::rules::SRange s_range(0., lane->length());
-  const maliput::api::rules::LaneSRange lane_s_range(lane->id(), s_range);
-  const std::vector<maliput::api::rules::LaneSRange> lane_s_ranges(1, lane_s_range);
+  const maliput::api::SRange s_range(0., lane->length());
+  const maliput::api::LaneSRange lane_s_range(lane->id(), s_range);
+  const std::vector<maliput::api::LaneSRange> lane_s_ranges(1, lane_s_range);
 
   return rn_->rulebook()->FindRules(lane_s_ranges, 0.);
 }

--- a/delphyne-gui/visualizer/maliput_viewer_model.hh
+++ b/delphyne-gui/visualizer/maliput_viewer_model.hh
@@ -19,7 +19,7 @@
 
 #include <maliput-utilities/generate_obj.h>
 #include <maliput-utilities/mesh.h>
-#include <maliput/api/rules/regions.h>
+#include <maliput/api/regions.h>
 #include <maliput/api/rules/right_of_way_rule.h>
 
 #include <ignition/common/Mesh.hh>
@@ -44,13 +44,13 @@ std::ostream& operator<<(std::ostream& out, const maliput::api::rules::RightOfWa
 std::ostream& operator<<(std::ostream& out, const maliput::api::rules::RightOfWayRule::State& state);
 
 // Serializes `s_range` into `out`.
-std::ostream& operator<<(std::ostream& out, const maliput::api::rules::SRange& s_range);
+std::ostream& operator<<(std::ostream& out, const maliput::api::SRange& s_range);
 
 // Serializes `lane_s_range` into `out`.
-std::ostream& operator<<(std::ostream& out, const maliput::api::rules::LaneSRange& lane_s_range);
+std::ostream& operator<<(std::ostream& out, const maliput::api::LaneSRange& lane_s_range);
 
 // Serializes `lane_s_route` into `out`.
-std::ostream& operator<<(std::ostream& out, const maliput::api::rules::LaneSRoute& lane_s_route);
+std::ostream& operator<<(std::ostream& out, const maliput::api::LaneSRoute& lane_s_route);
 
 // Serializes `zone_type` into `out`.
 std::ostream& operator<<(std::ostream& out, const maliput::api::rules::RightOfWayRule::ZoneType& zone_type);
@@ -97,7 +97,7 @@ class RoadNetworkQuery {
   void GetDirectionUsage(const maliput::api::LaneId& lane_id);
 
   /// Gets all right-of-way rules for the given `lane_s_range`.
-  void GetRightOfWay(const maliput::api::rules::LaneSRange& lane_s_range);
+  void GetRightOfWay(const maliput::api::LaneSRange& lane_s_range);
 
   /// Gets all right-of-way rules' states for a given phase in a given phase
   /// ring.
@@ -258,7 +258,7 @@ class MaliputViewerModel {
   /// must support concatenation via operator+.
   /// \return Right of way rules as a StringType representation.
   template <typename StringType>
-  StringType GetRightOfWayRules(const maliput::api::rules::LaneSRange& _laneSRange) const;
+  StringType GetRightOfWayRules(const maliput::api::LaneSRange& _laneSRange) const;
 
   /// \brief Get the max speed rules for a given lane id.
   /// \param[in] _laneId Id of the lane to get the max speed limit rules from.
@@ -328,7 +328,7 @@ StringType MaliputViewerModel::GetRulesOfLane(const std::string& _laneId) const 
   }
   maliput::api::LaneId id(_laneId);
   const maliput::api::RoadGeometry::IdIndex& roadIndex = this->roadNetwork->road_geometry()->ById();
-  maliput::api::rules::LaneSRange laneSRange(id, maliput::api::rules::SRange(0., roadIndex.GetLane(id)->length()));
+  maliput::api::LaneSRange laneSRange(id, maliput::api::SRange(0., roadIndex.GetLane(id)->length()));
   StringType rules = "[Right of way rules]\n" + GetRightOfWayRules<StringType>(laneSRange) + "\n" +
                      "[Max speed limit rules]\n" + GetMaxSpeedLimitRules<StringType>(id) + "\n" +
                      "[Direction usage rules]\n" + GetDirectionUsageRules<StringType>(id) + "\n";
@@ -336,7 +336,7 @@ StringType MaliputViewerModel::GetRulesOfLane(const std::string& _laneId) const 
 }
 
 template <typename StringType>
-StringType MaliputViewerModel::GetRightOfWayRules(const maliput::api::rules::LaneSRange& _laneSRange) const {
+StringType MaliputViewerModel::GetRightOfWayRules(const maliput::api::LaneSRange& _laneSRange) const {
   std::ostringstream rightOfWayRules;
   RoadNetworkQuery query(&rightOfWayRules, roadNetwork.get());
   query.GetRightOfWay(_laneSRange);


### PR DESCRIPTION
Related with [maliput's issue](https://github.com/ToyotaResearchInstitute/maliput/issues/117)