### PR TITLE
Fix erroneous car behavior in demos

### DIFF
--- a/delphyne-demos/demos/gazoo.py
+++ b/delphyne-demos/demos/gazoo.py
@@ -54,7 +54,6 @@ def create_gazoo_scenario_subtree(filename, mobil_cars_num):
     railcar_s = 0.0      # (m)
     robot_id = 1
     lane_1 = "l:s1_0"
-
     scenario_subtree.add_child(
         delphyne.behaviours.agents.RailCar(
             name=str(robot_id),
@@ -109,7 +108,6 @@ def create_gazoo_scenario_subtree(filename, mobil_cars_num):
                      0.0 + y_offset * (i % 3),
                      0.0
                 ),
-                direction_of_travel=0.0,
                 speed=velocity_base * i
             )
         )

--- a/delphyne-demos/demos/mobil_perf.py
+++ b/delphyne-demos/demos/mobil_perf.py
@@ -64,7 +64,6 @@ def curved_lanes(args):
                     R0 - R * math.cos(theta),  # m
                     theta  # rads
                 ),
-                direction_of_travel=False,
                 speed=1.,  # m/s
             )
         )
@@ -110,7 +109,6 @@ def straight_lanes(args):
                     4. * (i % 3),  # m
                     0.  # rads
                 ),
-                direction_of_travel=False,
                 speed=1.,  # m/s
             )
         )
@@ -158,7 +156,6 @@ def dragway(args):
                     -5.5 + 3.7 * (i % 4),  # m
                      0.  # rads
                 ),
-                direction_of_travel=False,
                 speed=1.,  # m/s
             )
         )


### PR DESCRIPTION
Since `direction_of_travel` defaults to `True`, remove the lines which set it to false.

Closes https://github.com/ToyotaResearchInstitute/delphyne-gui/issues/236