### PR TITLE
Remove wrong assertion on arrow visibility

### DIFF
--- a/delphyne-gui/visualizer/render_maliput_widget.cc
+++ b/delphyne-gui/visualizer/render_maliput_widget.cc
@@ -439,8 +439,9 @@ void RenderMaliputWidget::PutArrowAt(double _distance, const ignition::math::Vec
 }
 
 void RenderMaliputWidget::SetArrowVisibility(bool _visible) {
-  DELPHYNE_DEMAND(arrow != nullptr);
-  arrow->SetVisibility(_visible);
+  if (this->arrow) {
+    this->arrow->SetVisibility(_visible);
+  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
When one opens the maliput viewer, the arrow doesn't exists because it's created when a scene with roads is created. Instead of asserting, it's valid to not have an arrow created yet.