### PR TITLE
Matches with the maliput_copyable.h uses.

### DIFF
--- a/delphyne-gui/visualizer/CMakeLists.txt
+++ b/delphyne-gui/visualizer/CMakeLists.txt
@@ -135,6 +135,9 @@ add_library(${playback_widget} SHARED
   ${${playback_widget}_MOC}
   ${${playback_widget}_resources_RCC}
 )
+ament_target_dependencies(${playback_widget}
+  "maliput"
+)
 target_link_libraries(${playback_widget}
   ${IGNITION-COMMON_LIBRARIES}
   ${IGNITION-GUI_LIBRARIES}
@@ -144,6 +147,7 @@ target_link_libraries(${playback_widget}
   ${Qt5Widgets_LIBRARIES}
   delphyne::protobuf_messages
   delphyne::public_headers
+  maliput::common
 )
 
 install(TARGETS ${playback_widget} DESTINATION ${LIB_INSTALL_DIR} COMPONENT shlib)


### PR DESCRIPTION
> It matches with [maliput#246](https://github.com/ToyotaResearchInstitute/maliput/pull/246)