### PR TITLE
Adapt files to maliput::math::Vector3

### DIFF
--- a/delphyne-gui/visualizer/traffic_light_manager.cc
+++ b/delphyne-gui/visualizer/traffic_light_manager.cc
@@ -275,12 +275,12 @@ maliput::api::rules::Bulb::BoundingBox TrafficLightManager::CreateSingleBulb(
   // The visual used has a bounding box size of 1x1x1 meter.
   // Considering that the bulb's bounding box is symmetric and expressed in function of this size, it can be used
   // for a scale operation.
-  const Eigen::Vector3d& min_scale{
+  const maliput::math::Vector3& min_scale{
       bb.p_BMin.x(),
       bb.p_BMin.y(),
       bb.p_BMin.z(),
   };
-  const Eigen::Vector3d& max_scale{
+  const maliput::math::Vector3& max_scale{
       bb.p_BMax.x(),
       bb.p_BMax.y(),
       bb.p_BMax.z(),
@@ -306,13 +306,12 @@ maliput::api::rules::Bulb::BoundingBox TrafficLightManager::CreateSingleBulb(
   }
 
   maliput::api::rules::Bulb::BoundingBox bulb_world_bounding_box;
-  const Eigen::Vector3d kBMin(world_bounding_box_min.X() * std::abs(min_scale.x()),
-                              world_bounding_box_min.Y() * std::abs(min_scale.y()),
-                              world_bounding_box_min.Z() * std::abs(min_scale.z()));
-  bulb_world_bounding_box.p_BMin = {kBMin.x(), kBMin.y(), kBMin.z()};
-  const Eigen::Vector3d kBMax(world_bounding_box_max.X() * max_scale.x(), world_bounding_box_max.Y() * max_scale.y(),
-                              world_bounding_box_max.Z() * max_scale.z());
-  bulb_world_bounding_box.p_BMax = {kBMax.x(), kBMax.y(), kBMax.z()};
+  bulb_world_bounding_box.p_BMin.x() = world_bounding_box_min.X() * std::abs(min_scale.x());
+  bulb_world_bounding_box.p_BMin.y() = world_bounding_box_min.Y() * std::abs(min_scale.y());
+  bulb_world_bounding_box.p_BMin.z() = world_bounding_box_min.Z() * std::abs(min_scale.z());
+  bulb_world_bounding_box.p_BMax.x() = world_bounding_box_max.X() * std::abs(max_scale.x());
+  bulb_world_bounding_box.p_BMax.y() = world_bounding_box_max.Y() * std::abs(max_scale.y());
+  bulb_world_bounding_box.p_BMax.z() = world_bounding_box_max.Z() * std::abs(max_scale.z());
 
   visual->SetWorldScale(max_scale.x(), max_scale.y(), max_scale.z());
   const maliput::api::GeoPosition bulb_world_position = _bulbGroupWorldPosition + _single_bulb->position_bulb_group();


### PR DESCRIPTION
This PR matches with [maliput#248](https://github.com/ToyotaResearchInstitute/maliput/pull/248).

As the title says, files were adapted to match with `maliput::math::VectorN` implementation.