### PR TITLE
US5: Adds LShapeRoad.xodr to mali2 demo.

### DIFF
--- a/delphyne-demos/demos/mali2.py
+++ b/delphyne-demos/demos/mali2.py
@@ -56,6 +56,13 @@ KNOWN_ROADS = {
         'lane_position': 0.,
         'moving_forward': True,
     },
+    'LShapeRoadVariableLanes': {
+        'description': ('Variable number of lanes describing a L shape road.'),
+        'file_path': 'odr/LShapeRoadVariableLanes.xodr',
+        'lane_id': '1_0_1',
+        'lane_position': 0.,
+        'moving_forward': True,
+    },
 }
 
 

--- a/delphyne-demos/test/CMakeLists.txt
+++ b/delphyne-demos/test/CMakeLists.txt
@@ -22,6 +22,10 @@ if (NOT ${SANITIZERS})
     COMMAND ${PROJECT_SOURCE_DIR}/examples/delphyne-mali2 -n LShapeRoad -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_mali2_l_shape_road_variable_lanes
+    COMMAND ${PROJECT_SOURCE_DIR}/examples/delphyne-mali2 -n LShapeRoadVariableLanes -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_gazoo
     COMMAND ${PROJECT_SOURCE_DIR}/examples/delphyne-gazoo -b -d 2
   )


### PR DESCRIPTION
Resolves #289 

- Adds LShapeRoad.xodr to mali2 demo.

Rely on https://github.com/ToyotaResearchInstitute/malidrive/pull/471/
Rely on https://github.com/ToyotaResearchInstitute/malidrive/pull/473