### PR TITLE
US6: Adds TShapeRoad to mali2 demo.

### DIFF
--- a/delphyne-demos/demos/mali2.py
+++ b/delphyne-demos/demos/mali2.py
@@ -69,12 +69,6 @@ KNOWN_ROADS = {
         'lane_position': 0.,
         'moving_forward': True,
     },
-    'FlatTown01': {
-        'description': 'Town with multiples flat Roads and one lane section per road.',
-        'lane_id': '25_0_-1',
-        'lane_position': 0.,
-        'moving_forward': True,
-    },
 }
 
 

--- a/delphyne-demos/test/CMakeLists.txt
+++ b/delphyne-demos/test/CMakeLists.txt
@@ -30,10 +30,6 @@ if (NOT ${SANITIZERS})
     COMMAND ${PROJECT_SOURCE_DIR}/examples/delphyne-mali2 -n TShapeRoad -b -d 2
   )
   add_test(
-    NAME smoke_test_delphyne_mali2_flat_town_01
-    COMMAND ${PROJECT_SOURCE_DIR}/examples/delphyne-mali2 -n FlatTown01 -b -d 2
-  )
-  add_test(
     NAME smoke_test_delphyne_gazoo
     COMMAND ${PROJECT_SOURCE_DIR}/examples/delphyne-gazoo -b -d 2
   )


### PR DESCRIPTION
Resolves #291 

- Adds TShapeRoad.xodr ~and FlatTown01~ to mali2 demo.

 - [x] Rely on PR https://github.com/ToyotaResearchInstitute/malidrive/pull/478
 - [x] Rely on PR https://github.com/ToyotaResearchInstitute/malidrive/pull/480
 - [x] Rely on PR https://github.com/ToyotaResearchInstitute/malidrive/pull/481
 - [x] Rely on PR https://github.com/ToyotaResearchInstitute/malidrive/pull/484