### PR TITLE
Adds more maps to mali2/tests.

### DIFF
--- a/delphyne-demos/demos/mali2.py
+++ b/delphyne-demos/demos/mali2.py
@@ -110,8 +110,8 @@ KNOWN_ROADS = {
         'file_path': 'odr/RRLongRoad.xodr',
         'lane_id': '0_0_-4',
         'lane_position': 0.,
-        'moving_forward': False,
-        'linear_tolerance': 1e-3,
+        'moving_forward': True,
+        'linear_tolerance': 5e-2,
     },
     'Highway': {
         'description': 'Highway',
@@ -134,6 +134,13 @@ KNOWN_ROADS = {
         'moving_forward': True,
         'linear_tolerance': 1e-3,
     },
+    'RRFigure8': {
+        'description': '8-shaped road ',
+        'lane_id': '1_0_1',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 5e-2,
+    },
     'Town01': {
         'description': 'Grid city',
         'lane_id': '25_0_-1',
@@ -144,6 +151,13 @@ KNOWN_ROADS = {
     'Town02': {
         'description': 'Grid city',
         'lane_id': '1_0_1',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 5e-2,
+    },
+    'Town03': {
+        'description': 'Grid city',
+        'lane_id': '352_1_-1',
         'lane_position': 0.,
         'moving_forward': True,
         'linear_tolerance': 5e-2,
@@ -165,6 +179,13 @@ KNOWN_ROADS = {
     'Town06': {
         'description': 'Grid city',
         'lane_id': '75_0_3',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 5e-2,
+    },
+    'Town07': {
+        'description': 'Grid city',
+        'lane_id': '438_1_1',
         'lane_position': 0.,
         'moving_forward': True,
         'linear_tolerance': 5e-2,

--- a/delphyne-demos/test/CMakeLists.txt
+++ b/delphyne-demos/test/CMakeLists.txt
@@ -46,6 +46,10 @@ if (NOT ${SANITIZERS})
     COMMAND delphyne-mali2 -n SShapeSuperelevatedRoad -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_mali2_r_r_long_road
+    COMMAND delphyne-mali2 -n RRLongRoad -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_mali2_highway
     COMMAND delphyne-mali2 -n Highway -b -d 2
   )
@@ -58,12 +62,20 @@ if (NOT ${SANITIZERS})
     COMMAND delphyne-mali2 -n Figure8 -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_mali2_r_r_figure_8
+    COMMAND delphyne-mali2 -n RRFigure8 -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_mali2_town_01
     COMMAND delphyne-mali2 -n Town01 -b -d 2
   )
   add_test(
     NAME smoke_test_delphyne_mali2_town_02
     COMMAND delphyne-mali2 -n Town02 -b -d 2
+  )
+  add_test(
+    NAME smoke_test_delphyne_mali2_town_03
+    COMMAND delphyne-mali2 -n Town03 -b -d 2
   )
   add_test(
     NAME smoke_test_delphyne_mali2_town_04
@@ -76,6 +88,10 @@ if (NOT ${SANITIZERS})
   add_test(
     NAME smoke_test_delphyne_mali2_town_06
     COMMAND delphyne-mali2 -n Town06 -b -d 2
+  )
+  add_test(
+    NAME smoke_test_delphyne_mali2_town_07
+    COMMAND delphyne-mali2 -n Town07 -b -d 2
   )
   add_test(
     NAME smoke_test_delphyne_gazoo


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/malidrive/issues/571

XODRs were added to mali2 and those respective "smoke tests" were created.
```
RRLongRoad
RRFigure8
Town03
Town07
```
