### PR TITLE
Matches with the migration of malidrive::common.

### DIFF
--- a/delphyne-gui/cmake/SearchForStuff.cmake
+++ b/delphyne-gui/cmake/SearchForStuff.cmake
@@ -135,4 +135,5 @@ endif()
 # Find Delphyne
 find_package(delphyne REQUIRED)
 find_package(maliput REQUIRED)
+find_package(maliput_malidrive REQUIRED)
 find_package(maliput_multilane REQUIRED)


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/malidrive/issues/643
Matches with https://github.com/ToyotaResearchInstitute/malidrive/pull/670