### PR TITLE
Try to checkout same branch in dependencies

### DIFF
--- a/.github/try_vcs_checkout
+++ b/.github/try_vcs_checkout
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2020 Toyota Research Institute
+
+CHANGE_BRANCH=$1
+SRC_FOLDER=$2
+
+echo try checking out ${CHANGE_BRANCH}
+vcs custom $SRC_FOLDER --args branch -f $CHANGE_BRANCH origin/$CHANGE_BRANCH > /dev/null || true
+vcs custom $SRC_FOLDER --args merge --no-edit $CHANGE_BRANCH  > /dev/null || true
+DIFF=$(vcs diff -s $SRC_FOLDER | tr -d '.\n')
+if [ ! -z "$DIFF" ]; then
+    echo "Have merge conflicts!"
+    echo $DIFF
+    exit 1
+fi
+vcs status $SRC_FOLDER

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,17 @@ jobs:
     container:
       image: ubuntu:18.04
     steps:
+    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
+    - uses: ros-tooling/setup-ros@0.0.26
+    # install git from ppa since git 2.18+ is needed to fetch all branches from actions/checkout
+    # this step can be removed on 20.04
+    - name: install git from ppa
+      shell: bash
+      run: |
+        apt update;
+        apt install -y software-properties-common;
+        add-apt-repository -y -u ppa:git-core/ppa;
+        apt install -y git;
     - uses: actions/checkout@v2
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
@@ -22,40 +33,49 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-dragway
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_dragway
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-multilane
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_multilane
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/malidrive
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/malidrive
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/delphyne
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/delphyne
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/drake-vendor
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/drake_vendor
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/dsim-repos-index
+        fetch-depth: 0
         path: dsim-repos-index
         token: ${{ secrets.MALIPUT_TOKEN }}
-    # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@0.0.25
+    - name: check if dependencies have a matching branch
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}/src
+      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} .
     # install drake_vendor prereqs using dsim-repos-index/tools/prereqs.lib
     - name: install drake_vendor prereqs
       shell: bash


### PR DESCRIPTION
This is a port of the branch checkout behavior from https://github.com/ToyotaResearchInstitute/maliput-dragway/pull/18. I've tested it with the [eloquent branch](https://github.com/ToyotaResearchInstitute/delphyne-gui/compare/eloquent) that naively attempts to use `eloquent` in https://github.com/ToyotaResearchInstitute/delphyne-gui/commit/dfd57a0c0a02788d5bb528c0ee1c3f9b9f3403f0 but fails due to missing fixes from https://github.com/ToyotaResearchInstitute/maliput/pull/370 and https://github.com/ToyotaResearchInstitute/maliput-dragway/pull/20. Since those are also on `eloquent` branches in their respective repositories, adding the branch checkout behavior to the actions CI in https://github.com/ToyotaResearchInstitute/delphyne-gui/commit/642ff2212f566591a06d0d58d91d31115f09552f allows the `eloquent` branch to pass CI.

## Original description of branch checkout behavior

This implements some behavior from our Jenkins CI that
attempts to checkout a branch of the same name in all
dependency packages. This requires setting `fetch-depth: 0`
in the actions/checkout steps and installing git 2.18+
before those checkout steps. For 18.04, the git-core ppa
is used; this will not be needed on 20.04.