### PR TITLE
Revert some library renaming to fix demos

### DIFF
--- a/delphyne_gui/visualizer/CMakeLists.txt
+++ b/delphyne_gui/visualizer/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(maliput_mesh
 add_library(delphyne_gui::maliput_mesh ALIAS maliput_mesh)
 set_target_properties(maliput_mesh
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_maliput_mesh
+    OUTPUT_NAME MaliputMesh
 )
 
 ament_target_dependencies(maliput_mesh
@@ -38,7 +38,7 @@ add_library(global_attributes
 add_library(delphyne_gui::global_attributes ALIAS global_attributes)
 set_target_properties(global_attributes
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_global_attributes
+    OUTPUT_NAME GlobalAttributes
 )
 
 target_link_libraries(global_attributes
@@ -78,7 +78,7 @@ add_library(maliput_viewer_widget
 add_library(delphyne_gui::maliput_viewer_widget ALIAS maliput_viewer_widget)
 set_target_properties(maliput_viewer_widget
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_maliput_viewer_widget
+    OUTPUT_NAME MaliputViewerWidget
 )
 
 ament_target_dependencies(maliput_viewer_widget
@@ -123,7 +123,7 @@ add_library(render_widget
 add_library(delphyne_gui::render_widget ALIAS render_widget)
 set_target_properties(render_widget
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_render_widget
+    OUTPUT_NAME RenderWidget
 )
 
 target_link_libraries(render_widget
@@ -156,7 +156,7 @@ add_library(teleop_widget
 add_library(delphyne_gui::teleop_widget ALIAS teleop_widget)
 set_target_properties(teleop_widget
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_teleop_widget
+    OUTPUT_NAME TeleopWidget
 )
 
 target_link_libraries(teleop_widget
@@ -195,7 +195,7 @@ add_library(playback_widget
 add_library(delphyne_gui::playback_widget ALIAS playback_widget)
 set_target_properties(playback_widget
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_playback_widget
+    OUTPUT_NAME PlaybackWidget
 )
 
 target_link_libraries(playback_widget

--- a/delphyne_gui/visualizer/display_plugins/CMakeLists.txt
+++ b/delphyne_gui/visualizer/display_plugins/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(origin_display
 add_library(delphyne_gui::origin_display ALIAS origin_display)
 set_target_properties(origin_display
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_origin_display
+    OUTPUT_NAME OriginDisplay
 )
 
 target_link_libraries(origin_display
@@ -45,7 +45,7 @@ add_library(agent_info_display
 add_library(delphyne_gui::agent_info_display ALIAS agent_info_display)
 set_target_properties(agent_info_display
   PROPERTIES
-    OUTPUT_NAME delphyne_gui_agent_info_display
+    OUTPUT_NAME AgentInfoDisplay
 )
 
 target_link_libraries(agent_info_display


### PR DESCRIPTION
Some plugins were renamed in #334, which broke the demos (see #338). This reverts the changes to the output file names to fix the demos. We can change the names more carefully in a follow-up PR.