### PR TITLE
Restore delphyne_gui_ prefix to visualizer library names

### DIFF
--- a/delphyne_gui/visualizer/CMakeLists.txt
+++ b/delphyne_gui/visualizer/CMakeLists.txt
@@ -78,7 +78,7 @@ add_library(maliput_viewer_widget
 add_library(delphyne_gui::maliput_viewer_widget ALIAS maliput_viewer_widget)
 set_target_properties(maliput_viewer_widget
   PROPERTIES
-    OUTPUT_NAME MaliputViewerWidget
+    OUTPUT_NAME delphyne_gui_maliput_viewer_widget
 )
 
 ament_target_dependencies(maliput_viewer_widget
@@ -111,8 +111,6 @@ install(
 )
 
 # RenderWidget GUI plugin.
-set(render_widget RenderWidget)
-
 QT5_WRAP_CPP(RenderWidget_MOC render_widget.hh)
 
 add_library(render_widget
@@ -123,7 +121,7 @@ add_library(render_widget
 add_library(delphyne_gui::render_widget ALIAS render_widget)
 set_target_properties(render_widget
   PROPERTIES
-    OUTPUT_NAME RenderWidget
+    OUTPUT_NAME delphyne_gui_render_widget
 )
 
 target_link_libraries(render_widget
@@ -156,7 +154,7 @@ add_library(teleop_widget
 add_library(delphyne_gui::teleop_widget ALIAS teleop_widget)
 set_target_properties(teleop_widget
   PROPERTIES
-    OUTPUT_NAME TeleopWidget
+    OUTPUT_NAME delphyne_gui_teleop_widget
 )
 
 target_link_libraries(teleop_widget
@@ -195,7 +193,7 @@ add_library(playback_widget
 add_library(delphyne_gui::playback_widget ALIAS playback_widget)
 set_target_properties(playback_widget
   PROPERTIES
-    OUTPUT_NAME PlaybackWidget
+    OUTPUT_NAME delphyne_gui_playback_widget
 )
 
 target_link_libraries(playback_widget

--- a/delphyne_gui/visualizer/display_plugins/CMakeLists.txt
+++ b/delphyne_gui/visualizer/display_plugins/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(origin_display
 add_library(delphyne_gui::origin_display ALIAS origin_display)
 set_target_properties(origin_display
   PROPERTIES
-    OUTPUT_NAME OriginDisplay
+    OUTPUT_NAME delphyne_gui_origin_display
 )
 
 target_link_libraries(origin_display
@@ -35,7 +35,7 @@ install(
   ARCHIVE DESTINATION lib
 )
 
-# Origin display plugin.
+# Agent Info display plugin.
 QT5_WRAP_CPP(AgentInfoDisplay_MOC agent_info_display.hh)
 
 add_library(agent_info_display
@@ -45,7 +45,7 @@ add_library(agent_info_display
 add_library(delphyne_gui::agent_info_display ALIAS agent_info_display)
 set_target_properties(agent_info_display
   PROPERTIES
-    OUTPUT_NAME AgentInfoDisplay
+    OUTPUT_NAME delphyne_gui_agent_info_display
 )
 
 target_link_libraries(agent_info_display

--- a/delphyne_gui/visualizer/layout_for_playback.config
+++ b/delphyne_gui/visualizer/layout_for_playback.config
@@ -76,7 +76,7 @@
   </menus>
   <ignore>position</ignore>
 </window>
-<plugin filename="RenderWidget">
+<plugin filename="delphyne_gui_render_widget">
   <has_titlebar>false</has_titlebar>
 </plugin>
 <plugin filename="TopicInterface" read_only="true">
@@ -135,4 +135,4 @@
 </plugin>
 <plugin filename="TopicsStats"/>
 <plugin filename="TopicViewer"/>
-<plugin filename="PlaybackWidget"/>
+<plugin filename="delphyne_gui_playback_widget"/>

--- a/delphyne_gui/visualizer/layout_maliput_viewer.config
+++ b/delphyne_gui/visualizer/layout_maliput_viewer.config
@@ -15,6 +15,6 @@
   </menus>
 </window>
 
-<plugin filename="MaliputViewerWidget">
+<plugin filename="delphyne_gui_maliput_viewer_widget">
   <has_titlebar>false</has_titlebar>
 </plugin>

--- a/delphyne_gui/visualizer/layout_with_render_only.config
+++ b/delphyne_gui/visualizer/layout_with_render_only.config
@@ -14,14 +14,14 @@
     <plugins from_paths="false">
       <show>Requester</show>
       <show>Responder</show>
-      <show>TeleopWidget</show>
+      <show>delphyne_gui_teleop_widget</show>
       <show>TopicsStats</show>
       <show>TopicViewer</show>
     </plugins>
   </menus>
 </window>
 
-<plugin filename="RenderWidget">
+<plugin filename="delphyne_gui_render_widget">
   <has_titlebar>false</has_titlebar>
   <cast_shadows>false</cast_shadows>
 </plugin>

--- a/delphyne_gui/visualizer/layout_with_teleop.config
+++ b/delphyne_gui/visualizer/layout_with_teleop.config
@@ -73,7 +73,7 @@
       <show>Plot</show>
       <show>Requester</show>
       <show>Responder</show>
-      <show>TeleopWidget</show>
+      <show>delphyne_gui_teleop_widget</show>
       <show>TimePanel</show>
       <show>TopicInterface</show>
       <show>TopicsStats</show>
@@ -81,7 +81,7 @@
     </plugins>
   </menus>
 </window>
-<plugin filename="RenderWidget">
+<plugin filename="delphyne_gui_render_widget">
   <has_titlebar>false</has_titlebar>
 </plugin>
 
@@ -158,7 +158,7 @@
 
 <plugin filename="TopicViewer"/>
 
-<plugin filename="TeleopWidget">
+<plugin filename="delphyne_gui_teleop_widget">
   <car_number>0</car_number>
 </plugin>
 
@@ -172,7 +172,7 @@
       <pose>0 0 0 0 -0 0</pose>
       <color>0.7 0.7 0.7 0.3</color>
     </display>
-    <display type="OriginDisplay" />
-    <display type="AgentInfoDisplay" />
+    <display type="delphyne_gui_origin_display" />
+    <display type="delphyne_gui_agent_info_display" />
   </displays>
 </plugin>


### PR DESCRIPTION
As a follow-up to #340, re-add the `delphyne_gui_` prefix to visualizer library names and update the expected filenames in the layout configuration files so that the demos still work.