### PR TITLE
Modifies the maliput_viewer to be maliput_viewer0 and maliput_viewer2

### DIFF
--- a/delphyne_gui/CMakeLists.txt
+++ b/delphyne_gui/CMakeLists.txt
@@ -251,8 +251,10 @@ add_subdirectory(python)
 ament_environment_hooks(setup.sh.in)
 
 #################################################
-# Installs maliput_viewer.sh as a shortcut to run the visualizer.
-install (PROGRAMS tools/maliput_viewer.sh DESTINATION ${BIN_INSTALL_DIR})
+# Installs maliput_viewer0.sh and maliput_viewer2.sh as a shortcut to run both
+# visualizers.
+install (PROGRAMS tools/maliput_viewer0.sh DESTINATION ${BIN_INSTALL_DIR})
+install (PROGRAMS tools/maliput_viewer2.sh DESTINATION ${BIN_INSTALL_DIR})
 
 # Installs prereqs.
 install (PROGRAMS prereqs DESTINATION ${CMAKE_INSTALL_DATADIR})

--- a/delphyne_gui/tools/maliput_viewer0.sh
+++ b/delphyne_gui/tools/maliput_viewer0.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2018 Open Source Robotics Foundation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Shortcut to run `visualizer0` with the layout for the MaliputViewer.
+# CLI arguments will be forwarded to `visualizer`.
+# It is assumed that the environment is already configured.
+visualizer0 \
+  --layout=${DELPHYNE_GUI_RESOURCE_ROOT}/layouts/layout_maliput_viewer.config \
+  "$@"

--- a/delphyne_gui/tools/maliput_viewer2.sh
+++ b/delphyne_gui/tools/maliput_viewer2.sh
@@ -28,9 +28,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Shortcut to run `visualizer` with the layout for the MaliputViewer.
+# Shortcut to run `visualizer0` with the layout for the MaliputViewer.
 # CLI arguments will be forwarded to `visualizer`.
 # It is assumed that the environment is already configured.
-visualizer \
+visualizer2 \
   --layout=${DELPHYNE_GUI_RESOURCE_ROOT}/layouts/layout_maliput_viewer.config \
   "$@"


### PR DESCRIPTION
- Moves the maliput_viewer.sh script to maliput_viewer0.sh and changes the visualizer application to visualizer0.
- Creates another script to call visualizer2

This way, the old visualizer and the new one can be called via the script.