### PR TITLE
Use Scene3D plugin in default layout for visualizer2

### DIFF
--- a/delphyne_gui/visualizer/layout2_with_teleop.config
+++ b/delphyne_gui/visualizer/layout2_with_teleop.config
@@ -83,6 +83,7 @@
 </window>
 <plugin filename="Scene3D">
   <engine>ogre</engine>
+  <pose_topic>/visualizer/pose_update</pose_topic>
   <scene>scene</scene>
   <service>/get_scene</service>
   <has_titlebar>false</has_titlebar>


### PR DESCRIPTION
Requires https://github.com/ToyotaResearchInstitute/delphyne/pull/750. This updates the default layout for the new visualizer to use the `Scene3D` plugin from ign-gui2, with the `/get_scene` service and `/visualizer/pose_update` topic.

To test this, open a delphyne demo in the background (like `delphyne_gazoo &`) and then open `visualizer` as a separate process.