### PR TITLE
Set deletion_topic and scene_topic to fix warnings

### DIFF
--- a/delphyne_gui/visualizer/layout2_with_teleop.config
+++ b/delphyne_gui/visualizer/layout2_with_teleop.config
@@ -86,6 +86,13 @@
   <pose_topic>/visualizer/pose_update</pose_topic>
   <scene>scene</scene>
   <service>/get_scene</service>
+
+  <!-- The following two topics can be specified to support adding and deleting
+       models and lights from the scene. They are not currently used, but we
+       specify them here to prevent console warnings. -->
+  <deletion_topic>/unused_deletion_topic</deletion_topic>
+  <scene_topic>/unused_scene_topic</scene_topic>
+
   <has_titlebar>false</has_titlebar>
   <ambient_light>0 0 1</ambient_light>
   <background_color>0.8 0.8 0.8</background_color>


### PR DESCRIPTION
The Scene3D plugin can be configured with scene_topic and
deletion_topic names via xml. Information can be published
to these topics about models and lights to be added or
deleted from the scene. Delphyne is not yet using this
functionality, but we add unused topic names to the xml
to silence a console warning.

Code for `scene_topic`:

* subscriber: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L453-L468
* callback function expects `ignition::msgs::Scene` and copies it for later processing: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L401-L405
* Update function calls `LoadScene()`: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L342-L346
* `LoadScene()` adds any models or lights that haven't already been added to the scene: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L470-L500

Code for `deletion_topic`:

* subscriber: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L437-L451
* callback function expects `ignition::msgs::UInt32_V` with the unique Id of each mode / light to be deleted and copies it for later processing: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L329-L334
* Update function calls `DeleteEntity()`: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L348-L352
* `DeleteEntity()` deletes any models or lights matching the unique Ids: https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L792-L812

