### PR TITLE
Adds Grid3D display plugin.

### DIFF
--- a/delphyne_gui/visualizer/layout2_with_teleop.config
+++ b/delphyne_gui/visualizer/layout2_with_teleop.config
@@ -194,17 +194,14 @@
   <car_number>0</car_number>
 </plugin>
 
-<plugin filename="Displays">
-  <displays>
-    <display type="RealtimeFactorDisplay" />
-    <display type="GridDisplay">
-      <cell_count>250</cell_count>
-      <vertical_cell_count>0</vertical_cell_count>
-      <cell_length>1.000000</cell_length>
-      <pose>0 0 0 0 -0 0</pose>
-      <color>0.7 0.7 0.7 0.3</color>
-    </display>
-    <display type="delphyne_gui_origin_display" />
-    <display type="delphyne_gui_agent_info_display" />
-  </displays>
+<plugin filename="Grid3D">
+  <engine>ogre</engine>
+  <scene>scene</scene>
+  <insert>
+    <cell_count>250</cell_count>
+    <vertical_cell_count>0</vertical_cell_count>
+    <cell_length>1.000000</cell_length>
+    <pose>0 0 0 0 0 0</pose>
+    <color>0.7 0.7 0.7 0.3</color>
+  </insert>
 </plugin>


### PR DESCRIPTION
Part of #332 

Removes the Grid3D plugin from the Display plugin (it does not exist in ign-gui3) and keeps the same configuration as before.

![grid](https://user-images.githubusercontent.com/3825465/112662786-da7dfc80-8e36-11eb-9466-ef9203d7f050.png)

Note: we can see the plugin listed to the side which is different from before.