### PR TITLE
Fixes default layout when running demos.

### DIFF
--- a/delphyne_gui/python/utilities.py
+++ b/delphyne_gui/python/utilities.py
@@ -24,9 +24,9 @@ from contextlib import contextmanager
 
 @contextmanager
 def launch_interactive_simulation(simulation_runner,
-                                  layout="layout_with_teleop.config",
+                                  layout=None,
                                   bare=False, ign_visualizer=None):
-    """Defines a context manager function used to hande the execution of an
+    """Defines a context manager function used to handle the execution of an
     interactive simulation. An interactive simulation launches the delphyne
     visualizer in a separate process and ends the simulation when the
     visualizer is closed."""


### PR DESCRIPTION
Metaissue: #332

After https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/369 was merged a bug raised:


The method [`launch_interactive_simulation`](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/master/delphyne_gui/python/utilities.py#L26)'s argument `layout` is defaulted to `layout_for_teleop.config` which is a config file that only works with the old visualizer, so when the new visualizer is selected it keeps loading the old layout causing obviously bad behavior.
This bug showed up now as the `visualizer2` parses the `layout` argument.
