### PR TITLE
Adds TeleopPlugin with ignition-gui 3

### DIFF
--- a/delphyne_gui/visualizer/CMakeLists.txt
+++ b/delphyne_gui/visualizer/CMakeLists.txt
@@ -221,6 +221,50 @@ include_directories(
   ${CMAKE_SOURCE_DIR}
 )
 
+#-------------------------------------------------------------------------------
+# Teleop Plugin (ign-gui 3)
+QT5_WRAP_CPP(TeleopPlugin_headers_MOC teleop_plugin.h)
+QT5_ADD_RESOURCES(TeleopPlugin_RCC teleop_plugin.qrc)
+
+add_library(TeleopPlugin
+  ${CMAKE_CURRENT_SOURCE_DIR}/teleop_plugin.cc
+  ${TeleopPlugin_headers_MOC}
+  ${TeleopPlugin_RCC}
+)
+add_library(delphyne_gui::TeleopPlugin ALIAS TeleopPlugin)
+set_target_properties(TeleopPlugin
+  PROPERTIES
+    OUTPUT_NAME TeleopPlugin
+)
+
+target_link_libraries(TeleopPlugin
+  PUBLIC
+    ignition-gui3::ignition-gui3
+    ignition-common3::ignition-common3
+    ignition-transport8::ignition-transport8
+    ${Qt5Core_LIBRARIES}
+    ${Qt5Widgets_LIBRARIES}
+    delphyne::protobuf_messages
+  PRIVATE
+    ignition-plugin1::register
+)
+
+install(
+  TARGETS TeleopPlugin
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+include_directories(
+  ${Qt5Core_INCLUDE_DIRS}
+  ${CMAKE_BINARY_DIR}/include
+  ${CMAKE_SOURCE_DIR}
+)
+
+#-------------------------------------------------------------------------------
+
 # Visualizer with ign-gui0
 add_executable(visualizer0
   visualizer0.cc

--- a/delphyne_gui/visualizer/TeleopPlugin.qml
+++ b/delphyne_gui/visualizer/TeleopPlugin.qml
@@ -1,0 +1,150 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.1
+import QtQuick.Layouts 1.3
+
+Rectangle {
+  id: teleop
+  width: panel.implicitWidth + hideToolButton.width + 20
+  height: panel.implicitHeight + 10
+  color: "transparent"
+  Layout.minimumWidth: 290
+  Layout.minimumHeight: 110
+
+  Keys.onPressed: {
+    if (TeleopPlugin.isDriving) {
+      if (event.key == Qt.Key_Left) {
+        TeleopPlugin.UpdateSteeringAngle(1.0);
+        TeleopPlugin.newSteeringAngle = true;
+      } else if (event.key == Qt.Key_Right) {
+        TeleopPlugin.UpdateSteeringAngle(-1.0);
+        TeleopPlugin.newSteeringAngle = true;
+      } else if (event.key == Qt.Key_Up) {
+        TeleopPlugin.throttleKeyPressed = true;
+        TeleopPlugin.keepCurrentThrottle = false;
+      } else if (event.key == Qt.Key_Down) {
+        TeleopPlugin.brakeKeyPressed = true;
+        TeleopPlugin.keepCurrentBrake = false;
+      }
+    }
+  }
+
+  Keys.onReleased: {
+    if (!event.isAutoRepeat) {
+      if (event.key == Qt.Key_Space) {
+        TeleopPlugin.keepCurrentThrottle = true;
+        TeleopPlugin.keepCurrentBrake = true;
+      } else if (event.key == Qt.Key_Up) {
+        TeleopPlugin.throttleKeyPressed = false;
+      } else if (event.key == Qt.Key_Down) {
+        TeleopPlugin.brakeKeyPressed = false;
+      } else if (event.key == Qt.Key_Left || event.key == Qt.Key_Right) {
+        // do nothing
+        // this avoids the accel/brake values of not going down
+        // to zero after release when steering at the same time
+      }
+    }
+  }
+
+  RowLayout {
+    id: hideButton
+    height: teleop.height
+    ToolButton {
+      id: hideToolButton
+      text: panel.state === "hide" ? "\u2039" : "\u203A"
+      Layout.alignment: Qt.AlignBottom
+      font.pixelSize: 20
+      onClicked: {
+        panel.state = panel.state === "hide" ? "show" : "hide"
+      }
+    }
+  }
+
+  Rectangle {
+    id: panel
+    state: "hide"
+    default property alias data: grid.data
+    anchors.bottom: teleop.bottom
+    anchors.fill: parent
+    implicitWidth: grid.implicitWidth + 10
+    implicitHeight: grid.implicitHeight + 10
+    // color: "#22000000"
+    color: "transparent"
+
+    GridLayout {
+      id: grid
+      columns: 2
+      anchors.fill: parent
+      anchors.margins: 5
+
+      // Topic selection and start driving
+      TextField {
+        id: drivingTopic
+        text: TeleopPlugin.carNumber
+        selectByMouse: true
+        enabled: !TeleopPlugin.isDriving
+      }
+      Button {
+        id: startStopButton
+        text: "Start Driving"
+        font.capitalization: Font.MixedCase
+        onClicked: {
+          if (TeleopPlugin.isDriving) {
+            startStopButton.text = "Start Driving"
+            TeleopPlugin.isDriving = false
+          } else {
+            startStopButton.text = "Stop Driving"
+            TeleopPlugin.isDriving = true
+            // Hey! there are no bi-directional bindings.
+            TeleopPlugin.carNumber = drivingTopic.text
+            TeleopPlugin.OnStartDriving()
+          }
+          drivingTopic.enabled = !TeleopPlugin.isDriving
+          teleop.focus = true
+        }
+      }
+      // Steering angle
+      Label {
+        text: "Steering Angle:"
+        visible: true
+        font.weight: Font.DemiBold
+        Layout.alignment: Qt.AlignLeft
+      }
+      Label {
+        id: steeringAngleLabel
+        text: TeleopPlugin.steeringAngleValue
+        visible: true
+        font.weight: Font.DemiBold
+        Layout.alignment: Qt.AlignRight
+      }
+      // Throttle value
+      Label {
+        text: "Throttle Value:"
+        visible: true
+        font.weight: Font.DemiBold
+        Layout.alignment: Qt.AlignLeft
+      }
+      Label {
+        id: throttleValueLabel
+        text: TeleopPlugin.throttleValue
+        visible: true
+        font.weight: Font.DemiBold
+        Layout.alignment: Qt.AlignRight
+      }
+      // Brake value
+      Label {
+        text: "Brake Value:"
+        visible: true
+        font.weight: Font.DemiBold
+        Layout.alignment: Qt.AlignLeft
+      }
+      Label {
+        id: brakeValueLabel
+        text: TeleopPlugin.brakeValue
+        visible: true
+        font.weight: Font.DemiBold
+        Layout.alignment: Qt.AlignRight
+      }
+    }
+  }
+}

--- a/delphyne_gui/visualizer/layout2_with_teleop.config
+++ b/delphyne_gui/visualizer/layout2_with_teleop.config
@@ -201,10 +201,6 @@
   </ignition-gui>
 </plugin>
 
-<plugin filename="delphyne_gui_teleop_widget">
-  <car_number>0</car_number>
-</plugin>
-
 <plugin filename="Grid3D">
   <engine>ogre</engine>
   <scene>scene</scene>
@@ -215,4 +211,8 @@
     <pose>0 0 0 0 0 0</pose>
     <color>0.7 0.7 0.7 0.3</color>
   </insert>
+</plugin>
+
+<plugin filename="TeleopPlugin">
+  <car_number>0</car_number>
 </plugin>

--- a/delphyne_gui/visualizer/teleop_plugin.cc
+++ b/delphyne_gui/visualizer/teleop_plugin.cc
@@ -1,0 +1,114 @@
+// Copyright 2021 Toyota Research Institute
+#include "teleop_plugin.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+
+#include <ignition/common/Console.hh>
+#include <ignition/plugin/Register.hh>
+
+#include <delphyne/protobuf/automotive_driving_command.pb.h>
+
+namespace delphyne {
+namespace gui {
+namespace {
+
+// @brief Gets seconds and nanoseconds from the current time.
+// @param[out] sec The seconds component of the current time.
+// @param[out] nsec The nanoseconds component of the current time.
+void GetCurrentTime(int64_t* sec, int32_t* nsec) {
+  const auto now = std::chrono::system_clock::now();
+  const auto epoch = now.time_since_epoch();
+  const int64_t count = epoch.count();
+  *nsec = static_cast<int32_t>(count % 1000000000l);
+  *sec = (count - static_cast<int64_t>(*nsec)) / 1000000000l;
+}
+
+}  // namespace
+
+TeleopPlugin::TeleopPlugin() { timer.start(kTimerPeriodInMs, this); }
+
+void TeleopPlugin::LoadConfig(const tinyxml2::XMLElement* _pluginElem) {
+  if (title.empty()) {
+    title = "Teleop";
+  }
+
+  if (_pluginElem) {
+    if (auto agentChannel = _pluginElem->FirstChildElement("car_number")) {
+      SetCarNumber(QString::fromStdString("teleop/" + std::string(agentChannel->GetText())));
+    }
+  } else {
+    SetCarNumber("teleop/0");
+  }
+}
+
+void TeleopPlugin::OnStartDriving() {
+  publisher = std::make_unique<ignition::transport::Node::Publisher>();
+  *publisher = node.Advertise<ignition::msgs::AutomotiveDrivingCommand>("/" + carNumber);
+}
+
+void TeleopPlugin::UpdateBrakeValue(double brakeGradient) {
+  brakeValue = std::clamp(brakeValue + kBrakeScale * brakeGradient, kMinBrakeValue, kMaxBrakeValue);
+  BrakeValueChanged();
+}
+
+void TeleopPlugin::UpdateThrottleValue(double throttleGradient) {
+  throttleValue = std::clamp(throttleValue + kThrottleScale * throttleGradient, kMinThrottleValue, kMaxBrakeValue);
+  ThrottleValueChanged();
+}
+
+void TeleopPlugin::UpdateSteeringAngle(double sign) {
+  steeringAngleValue = std::clamp(steeringAngleValue + kStepSteeringAngle * sign, kMinSteeringAngle, kMaxSteeringAngle);
+  SteeringAngleValueChanged();
+}
+
+void TeleopPlugin::timerEvent(QTimerEvent* _event) {
+  if (_event->timerId() != timer.timerId()) {
+    return;
+  }
+  if (!isDriving) {
+    return;
+  }
+
+  const double oldThrottleValue = throttleValue;
+  const double oldBrakeValue = brakeValue;
+
+  if (!keepCurrentThrottle) {
+    UpdateThrottleValue(throttleKeyPressed ? 1.0 : -6.0);
+  }
+
+  if (!keepCurrentBrake) {
+    UpdateBrakeValue(brakeKeyPressed ? 1.0 : -6.0);
+  }
+
+  if (oldThrottleValue != throttleValue /* new throttle value */ || oldBrakeValue != brakeValue /* new brake value */ ||
+      newSteeringAngle /* new steering angle */) {
+    ignition::msgs::AutomotiveDrivingCommand ignMsg;
+
+    // Note: we don't set the header here since the bridge completely
+    // ignores it.
+    int32_t nsec;
+    int64_t sec;
+    GetCurrentTime(&sec, &nsec);
+    ignMsg.mutable_time()->set_sec(sec);
+    ignMsg.mutable_time()->set_nsec(nsec);
+
+    ignMsg.set_acceleration(throttleValue - brakeValue);
+    ignMsg.set_theta(steeringAngleValue);
+
+    publisher->Publish(ignMsg);
+
+    SteeringAngleValueChanged();
+    ThrottleValueChanged();
+    BrakeValueChanged();
+    SetNewSteeringAngle(false);
+  }
+}
+
+}  // namespace gui
+}  // namespace delphyne
+
+// Register this plugin
+IGNITION_ADD_PLUGIN(delphyne::gui::TeleopPlugin, ignition::gui::Plugin)

--- a/delphyne_gui/visualizer/teleop_plugin.h
+++ b/delphyne_gui/visualizer/teleop_plugin.h
@@ -1,0 +1,231 @@
+// Copyright 2021 Toyota Research Institute
+#pragma once
+
+#include <cmath>
+#include <memory>
+#include <string>
+
+#include <ignition/gui/Plugin.hh>
+#include <ignition/transport.hh>
+
+namespace delphyne {
+namespace gui {
+
+/// @brief Implements a teleoperation plugin.
+/// @details See TeleopPlugin.qml to complete understand how the view is
+///          connected to each QProperty.
+///          The plugin has a text input in which users must place the topic
+///          name of the agent to teleoperate. Topic name should be: <teleop/X>
+///          where X is the agent number. The plugin appends an extra "/" at the
+///          beginning to match topic names.
+///          When "Start Driving" is clicked, use:
+///          - ↑ to throttle.
+///          - ↓ to brake.
+///          - ← to steer left.
+///          - → to steer right.
+///          Note that when either throttling or braking, if ↑ or ↓ are released
+///          both values will return to zero. However, that does not happen with
+///          the steering control.
+///          To "Stop Driving", click again the button.
+class TeleopPlugin : public ignition::gui::Plugin {
+  Q_OBJECT
+
+  Q_PROPERTY(QString carNumber READ CarNumber WRITE SetCarNumber NOTIFY CarNumberChanged)
+
+  Q_PROPERTY(
+      QString steeringAngleValue READ SteeringAngleValue WRITE SetSteeringAngleValue NOTIFY SteeringAngleValueChanged)
+
+  Q_PROPERTY(QString throttleValue READ ThrottleValue WRITE SetThrottleValue NOTIFY ThrottleValueChanged)
+
+  Q_PROPERTY(QString brakeValue READ BrakeValue WRITE SetBrakeValue NOTIFY BrakeValueChanged)
+
+  Q_PROPERTY(bool newSteeringAngle READ NewSteeringAngle WRITE SetNewSteeringAngle NOTIFY NewSteeringAngleChanged)
+
+  Q_PROPERTY(
+      bool throttleKeyPressed READ ThrottleKeyPressed WRITE SetThrottleKeyPressed NOTIFY ThrottleKeyPressedChanged)
+
+  Q_PROPERTY(
+      bool keepCurrentThrottle READ KeepCurrentThrottle WRITE SetKeepCurrentThrottle NOTIFY KeepCurrentThrottleChanged)
+
+  Q_PROPERTY(bool brakeKeyPressed READ BrakeKeyPressed WRITE SetBrakeKeyPressed NOTIFY BrakeKeyPressedChanged)
+
+  Q_PROPERTY(bool keepCurrentBrake READ KeepCurrentBrake WRITE SetKeepCurrentBrake NOTIFY KeepCurrentBrakeChanged)
+
+  Q_PROPERTY(bool isDriving READ IsDriving WRITE SetIsDriving NOTIFY IsDrivingChanged)
+
+ public:
+  /// @brief Constructor.
+  /// @details Starts the timer and connects it to `timerEvent()`.
+  TeleopPlugin();
+
+  /// @brief Loads the plugin configuration.
+  /// @details Expects to find `car_number` only which is translated to
+  //           `teleop/<car_number>` as topic name.
+  void LoadConfig(const tinyxml2::XMLElement* _pluginElem);
+
+  Q_INVOKABLE QString BrakeValue() const { return QString::number(brakeValue, /* format */ 'f', /* precision */ 2); }
+
+  Q_INVOKABLE QString CarNumber() const { return QString::fromStdString(carNumber); }
+
+  Q_INVOKABLE QString SteeringAngleValue() const {
+    return QString::number(steeringAngleValue, /* format */ 'f', /* precision */ 2);
+  }
+
+  Q_INVOKABLE QString ThrottleValue() const {
+    return QString::number(throttleValue, /* format */ 'f', /* precision */ 2);
+  }
+
+  Q_INVOKABLE bool NewSteeringAngle() const { return newSteeringAngle; }
+
+  Q_INVOKABLE bool ThrottleKeyPressed() const { return throttleKeyPressed; }
+
+  Q_INVOKABLE bool KeepCurrentThrottle() const { return keepCurrentThrottle; }
+
+  Q_INVOKABLE bool BrakeKeyPressed() const { return brakeKeyPressed; }
+
+  Q_INVOKABLE bool KeepCurrentBrake() const { return keepCurrentBrake; }
+
+  Q_INVOKABLE bool IsDriving() const { return isDriving; }
+
+  Q_INVOKABLE void SetNewSteeringAngle(bool _newSteeringAngle) {
+    newSteeringAngle = _newSteeringAngle;
+    NewSteeringAngleChanged();
+  }
+
+  Q_INVOKABLE void SetThrottleKeyPressed(bool _throttleKeyPressed) {
+    throttleKeyPressed = _throttleKeyPressed;
+    ThrottleKeyPressedChanged();
+  }
+
+  Q_INVOKABLE void SetKeepCurrentThrottle(bool _keepCurrentThrottle) {
+    keepCurrentThrottle = _keepCurrentThrottle;
+    KeepCurrentThrottleChanged();
+  }
+
+  Q_INVOKABLE void SetBrakeKeyPressed(bool _brakeKeyPressed) {
+    brakeKeyPressed = _brakeKeyPressed;
+    BrakeKeyPressedChanged();
+  }
+
+  Q_INVOKABLE void SetKeepCurrentBrake(bool _keepCurrentBrake) {
+    keepCurrentBrake = _keepCurrentBrake;
+    KeepCurrentBrakeChanged();
+  }
+
+  Q_INVOKABLE void SetIsDriving(bool _isDriving) {
+    isDriving = _isDriving;
+    IsDrivingChanged();
+  }
+
+  Q_INVOKABLE void SetCarNumber(const QString& _carNumber) {
+    carNumber = _carNumber.toStdString();
+    CarNumberChanged();
+  }
+
+  Q_INVOKABLE void SetSteeringAngleValue(const QString& _steeringAngleValue) {
+    steeringAngleValue = _steeringAngleValue.toDouble();
+    SteeringAngleValueChanged();
+  }
+
+  Q_INVOKABLE void SetThrottleValue(const QString& _throttleValue) {
+    throttleValue = _throttleValue.toDouble();
+    ThrottleValueChanged();
+  }
+
+  Q_INVOKABLE void SetBrakeValue(const QString& _brakeValue) {
+    brakeValue = _brakeValue.toDouble();
+    BrakeValueChanged();
+  }
+
+ public slots:
+
+  /// @brief Callback in Qt thread when start driving is clicked.
+  void OnStartDriving();
+
+  /// @brief Updates the steering angle from the plugin UI.
+  /// @param sign It should be either 1.0 or -1.0 to move the handle wheel.
+  void UpdateSteeringAngle(double sign);
+
+ signals:
+
+  /// @{ Signals to notify that properties changed.
+  void CarNumberChanged();
+  void SteeringAngleValueChanged();
+  void ThrottleValueChanged();
+  void BrakeValueChanged();
+  void NewSteeringAngleChanged();
+  void ThrottleKeyPressedChanged();
+  void KeepCurrentThrottleChanged();
+  void BrakeKeyPressedChanged();
+  void KeepCurrentBrakeChanged();
+  void IsDrivingChanged();
+  /// @} Signals to notify that properties changed.
+
+ protected:
+  /// @brief Timer event callback which handles the logic of publishing driving
+  ///        commands.
+  void timerEvent(QTimerEvent* event) override;
+
+ private:
+  /// @{ Constants used in the implementation.
+  static constexpr double kStepSteeringAngle{45. / 180. * M_PI / 100.};
+  static constexpr double kMinSteeringAngle{-45. / 180. * M_PI};
+  static constexpr double kMaxSteeringAngle{45. / 180. * M_PI};
+
+  // Target velocity 60mph, i.e. ~26.8224 m/sec
+  static constexpr double kMaxVelocity{26.8224};
+
+  static constexpr double kThrottleScale{kMaxVelocity / 300.0};
+  static constexpr double kMinThrottleValue{0.};
+  static constexpr double kMaxThrottleValue{kMaxVelocity};
+
+  static constexpr double kBrakeScale{kMaxVelocity / 300.0};
+  static constexpr double kMinBrakeValue{0.};
+  static constexpr double kMaxBrakeValue{kMaxVelocity};
+
+  static constexpr int kTimerPeriodInMs{10};
+  /// @} Constants used in the implementation.
+
+  /// @brief Updates the throttle value.
+  /// @param throttleGradient The value to increase the throttle.
+  void UpdateThrottleValue(double throttleGradient);
+
+  /// @brief Updates the brake value.
+  /// @param brakeGradient The value to increase the brake.
+  void UpdateBrakeValue(double brakeGradient);
+
+  /// @{ QProperties.
+  std::string carNumber;
+
+  double steeringAngleValue{0.0};
+
+  double throttleValue{0.0};
+
+  double brakeValue{0.0};
+
+  bool newSteeringAngle{false};
+
+  bool throttleKeyPressed{false};
+
+  bool keepCurrentThrottle{false};
+
+  bool brakeKeyPressed{false};
+
+  bool keepCurrentBrake{false};
+
+  bool isDriving{false};
+  /// @} QProperties.
+
+  /// @brief Triggers an event every `kTimerPeriodInMs` to process the command
+  ///        to send to the agent.
+  QBasicTimer timer;
+
+  /// @brief Transport node.
+  ignition::transport::Node node;
+
+  /// @brief Transport publisher.
+  std::unique_ptr<ignition::transport::Node::Publisher> publisher;
+};
+
+}  // namespace gui
+}  // namespace delphyne

--- a/delphyne_gui/visualizer/teleop_plugin.qrc
+++ b/delphyne_gui/visualizer/teleop_plugin.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+  <qresource prefix="TeleopPlugin/">
+    <file>TeleopPlugin.qml</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
- Replicates UI from TeleopWidget which uses ign-gui0.
- Implements the same functionality.
- Missing automatic horizontal span.

https://user-images.githubusercontent.com/3825465/113214701-39d17780-9250-11eb-843c-36c4483454a0.mp4


To simplify reviewer's labor:
- Key events were migrated to TeleopPlugin.qml  because it is just simpler to handle there.
- Button logic (change of label and driving flag) was migrated to TeleopPlugin.qml  because it is just simpler to handle there.
- Almost all state attributes are QProperties, it is way simpler to share state and do bindings.

I did not intend to change behavior, if you find anything odd please let me know.

Part of #332