### PR TITLE
Allows selecting malidrive backend for the maliput viewer.

### DIFF
--- a/delphyne_gui/visualizer/maliput_viewer_model.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_model.cc
@@ -378,10 +378,11 @@ maliput::api::rules::RoadRulebook::QueryResults RoadNetworkQuery::FindRulesFor(c
 /////////////////////////////////////////////////
 void MaliputViewerModel::SetOpenDriveBackend(const std::string& _malidriveBackend) {
   if (_malidriveBackend != "opendrive_sdk" && _malidriveBackend != "malidrive2") {
-    std::cerr << " Unknown OpenDRIVE backend: <" << _malidriveBackend << ">. Using <opendrive_sdk> by default."
-              << std::endl;
+    ignerr << " Unknown OpenDRIVE backend: <" << _malidriveBackend << ">. Using <opendrive_sdk> by default."
+           << std::endl;
     malidriveBackend = "opendrive_sdk";
   } else {
+    ignmsg << "Using " << _malidriveBackend << " backend." << std::endl;
     malidriveBackend = _malidriveBackend;
   }
 }

--- a/delphyne_gui/visualizer/maliput_viewer_plugin.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin.cc
@@ -113,12 +113,12 @@ MaliputViewerPlugin::MaliputViewerPlugin() : Plugin() {
 
   // Loads the maliput file path if any and parses it.
   if (GlobalAttributes::HasArgument("xodr_file")) {
-    if (GlobalAttributes::HasArgument("malidrive_backend")) {
-      model->SetOpenDriveBackend(GlobalAttributes::GetArgument("malidrive_backend"));
-    }
     model->Load(GlobalAttributes::GetArgument("xodr_file"));
   } else if (GlobalAttributes::HasArgument("yaml_file")) {
     model->Load(GlobalAttributes::GetArgument("yaml_file"));
+  }
+  if (GlobalAttributes::HasArgument("malidrive_backend")) {
+    model->SetOpenDriveBackend(GlobalAttributes::GetArgument("malidrive_backend"));
   }
 }
 

--- a/delphyne_gui/visualizer/maliput_viewer_widget.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_widget.cc
@@ -148,6 +148,9 @@ void MaliputViewerWidget::OnNewRoadNetwork(const std::string& filePath, const st
 
   // Loads the new file.
   this->model = std::make_unique<MaliputViewerModel>();
+  if (GlobalAttributes::HasArgument("malidrive_backend")) {
+    this->model->SetOpenDriveBackend(GlobalAttributes::GetArgument("malidrive_backend"));
+  }
   this->model->Load(filePath, roadRulebookFilePath, trafficLightRulesFilePath, phaseRingFilePath);
   this->rulesVisualizerWidget->ClearText();
   this->rulesVisualizerWidget->ClearLaneList();


### PR DESCRIPTION
Related to [this Slack thread](https://drakedevelopers.slack.com/archives/G9XS1JS0J/p1620873613043000).


When running the `maliput_viewer` visualizer the malidrive backend could be selected by adding:
```
--malidrive_backend=opendrive_sdk
```
or
```
--malidrive_backend=malidrive2
```
if none is provided by default it is using the `opendrive_sdk`


**It works for both visualizer:**

Based on ign-gui0 visualizer:
```
maliput_viewer0.sh --malidrive_backend=malidrive2
maliput_viewer0.sh --malidrive_backend=opendrive_sdk
```

Based on ign-gui3 visualizer:
```
maliput_viewer2.sh --malidrive_backend=malidrive2
maliput_viewer2.sh --malidrive_backend=opendrive_sdk
```