### PR TITLE
MaliputViewer: Adds segment and junction id information.

### DIFF
--- a/delphyne_gui/visualizer/maliput_viewer_plugin/InfoArea.qml
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/InfoArea.qml
@@ -31,9 +31,9 @@ GridLayout {
     anchors.top: titleText.bottom
     anchors.left: parent.left
     width: parent.width
-    Layout.minimumHeight: 80
-    Layout.preferredHeight: 100
-    Layout.maximumHeight: 100
+    Layout.minimumHeight: 100
+    Layout.preferredHeight: 140
+    Layout.maximumHeight: 150
     Layout.fillWidth: true
     font.pixelSize: 12
     font.family: "Helvetica"

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.cc
@@ -642,6 +642,8 @@ void MaliputViewerPlugin::UpdateLaneInfoArea(const ignition::math::Vector3d& _po
   ss << "\nHBounds ------> "
      << "(min: " << lane->elevation_bounds(lane_pos.lane_position.s(), lane_pos.lane_position.r()).min()
      << ", max: " << lane->elevation_bounds(lane_pos.lane_position.s(), lane_pos.lane_position.r()).max() << ")";
+  ss << "\nSegmentId: ------------> " << lane->segment()->id().string();
+  ss << "\nJunctionId: ------------> " << lane->segment()->junction()->id().string();
   ss << "\n----  LANE BOUNDARIES (INERTIAL FRAME)  ----";
   ss << "\n(s, r, h) ------> (x, y, z)";
   ss << "\n(0, 0, 0) ----------> " << lane->ToInertialPosition({0., 0., 0.});


### PR DESCRIPTION
It just adds useful information about the segment and junction ids of the selected lanes.

The next step of this should be to use a table to provide tidier information (https://github.com/ToyotaResearchInstitute/delphyne_gui/issues/417)
But I prefer to add this right away and work on the table later on.