### PR TITLE
Prevents a nullptr exception when clicking in an empty scene

### DIFF
--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.hh
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.hh
@@ -196,6 +196,9 @@ class MaliputViewerModel {
             const std::string& _trafficLightBook = std::string(),
             const std::string& _phaseRingFilePath = std::string());
 
+  /// \return True when any of roadGeometry and roadNetwork are not nullptr.
+  bool IsInitialized() const { return roadGeometry.get() != nullptr || roadNetwork.get() != nullptr; }
+
   /// \brief Getter of the map of meshes.
   /// \return The map of meshes.
   const std::map<std::string, std::unique_ptr<MaliputMesh>>& Meshes() const;

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.cc
@@ -565,22 +565,24 @@ ignition::gui::Plugin* MaliputViewerPlugin::FilterPluginsByTitle(const std::stri
 }
 
 bool MaliputViewerPlugin::eventFilter(QObject* _obj, QEvent* _event) {
-  if (_event->type() == QEvent::Type::MouseButtonPress) {
-    const QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(_event);
-    if (mouseEvent && mouseEvent->button() == Qt::LeftButton) {
-      MouseClickHandler(mouseEvent);
+  if (model->IsInitialized()) {
+    if (_event->type() == QEvent::Type::MouseButtonPress) {
+      const QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(_event);
+      if (mouseEvent && mouseEvent->button() == Qt::LeftButton) {
+        MouseClickHandler(mouseEvent);
+      }
     }
-  }
-  if (_event->type() == ignition::gui::events::Render::kType) {
-    arrow->Update();
-    trafficLightManager->Tick();
-    if (renderMeshesOption.executeMeshRendering) {
-      RenderRoadMeshes(model->Meshes());
-      renderMeshesOption.executeMeshRendering = false;
-    }
-    if (renderMeshesOption.executeLabelRendering) {
-      RenderLabels(model->Labels());
-      renderMeshesOption.executeLabelRendering = false;
+    if (_event->type() == ignition::gui::events::Render::kType) {
+      arrow->Update();
+      trafficLightManager->Tick();
+      if (renderMeshesOption.executeMeshRendering) {
+        RenderRoadMeshes(model->Meshes());
+        renderMeshesOption.executeMeshRendering = false;
+      }
+      if (renderMeshesOption.executeLabelRendering) {
+        RenderLabels(model->Labels());
+        renderMeshesOption.executeLabelRendering = false;
+      }
     }
   }
   // Standard event processing


### PR DESCRIPTION
When the RoadGeometry is not loaded one clicks in the scene, events might request information from the model which holds the RoadGeometry but it is not there. An extra function to check for model initialization has been added to avoid null pointer deference.