### PR TITLE
Fix includes with <> instead of "" when using foreign header files

### DIFF
--- a/delphyne_gui/visualizer/render_maliput_widget.hh
+++ b/delphyne_gui/visualizer/render_maliput_widget.hh
@@ -17,10 +17,10 @@
 
 #include <QtWidgets/QWidget>
 
-#include "maliput_viewer_plugin/arrow_mesh.hh"
-#include "maliput_viewer_plugin/maliput_viewer_model.hh"
-#include "maliput_viewer_plugin/selector.hh"
-#include "maliput_viewer_plugin/traffic_light_manager.hh"
+#include <maliput_viewer_plugin/arrow_mesh.hh>
+#include <maliput_viewer_plugin/maliput_viewer_model.hh>
+#include <maliput_viewer_plugin/selector.hh>
+#include <maliput_viewer_plugin/traffic_light_manager.hh>
 #include "orbit_view_control.hh"
 
 namespace delphyne {


### PR DESCRIPTION
Replace #include "maliput/*" with #include <maliput/*> and likewise for maliput_*.

This will help prepare for the clang-format preferences on 20.04.

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196