### PR TITLE
Removes ament_target_dependencies() macro.

### DIFF
--- a/delphyne_gui/visualizer/maliput_viewer_plugin/CMakeLists.txt
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/CMakeLists.txt
@@ -16,11 +16,6 @@ set_target_properties(maliput_viewer_model
     OUTPUT_NAME delphyne_gui_maliput_viewer_model
 )
 
-ament_target_dependencies(maliput_viewer_model
-  "maliput"
-  "maliput_multilane"
-)
-
 target_link_libraries(maliput_viewer_model
   ${drake_LIBRARIES}
   delphyne::public_headers
@@ -76,10 +71,6 @@ set_target_properties(selector
     OUTPUT_NAME delphyne_gui_selector
 )
 
-ament_target_dependencies(selector
-  "maliput"
-)
-
 target_link_libraries(selector
   delphyne::public_headers
   ignition-common3::ignition-common3
@@ -105,10 +96,6 @@ add_library(delphyne_gui::traffic_light_manager ALIAS traffic_light_manager)
 set_target_properties(traffic_light_manager
   PROPERTIES
     OUTPUT_NAME delphyne_gui_traffic_light_manager
-)
-
-ament_target_dependencies(traffic_light_manager
-  "maliput"
 )
 
 target_link_libraries(traffic_light_manager

--- a/delphyne_gui/visualizer/playback_plugin/CMakeLists.txt
+++ b/delphyne_gui/visualizer/playback_plugin/CMakeLists.txt
@@ -20,10 +20,6 @@ set_target_properties(PlaybackPlugin
     OUTPUT_NAME PlaybackPlugin
 )
 
-ament_target_dependencies(PlaybackPlugin
-  "maliput"
-)
-
 target_link_libraries(PlaybackPlugin
   PUBLIC
     ignition-common3::ignition-common3


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196

Removes `ament_target_dependencies()`