### PR TITLE
Removes dependency on maliput_malidrive.

### DIFF
--- a/delphyne_gui/cmake/SearchForStuff.cmake
+++ b/delphyne_gui/cmake/SearchForStuff.cmake
@@ -119,5 +119,4 @@ endif()
 # Find Delphyne
 find_package(delphyne REQUIRED)
 find_package(maliput REQUIRED)
-find_package(maliput_malidrive REQUIRED)
 find_package(maliput_multilane REQUIRED)


### PR DESCRIPTION
`delphyne::roads` library is used instead so no need to depend on `maliput_malidrive` (note that only we are looking for the package).