### PR TITLE
Changes the plugin path to the install space instead the build space.

### DIFF
--- a/delphyne_gui/cmake/config.hh.in
+++ b/delphyne_gui/cmake/config.hh.in
@@ -10,7 +10,7 @@
 
 #define DELPHYNE_GUI_VERSION_HEADER "${PROJECT_NAME_LOWER}, version ${PROJECT_VERSION_FULL}\nCopyright (C) 2017 Open Source Robotics Foundation.\nReleased under the Apache 2.0 License.\n\n"
 
-#define PLUGIN_INSTALL_PATH "${CMAKE_BINARY_DIR}/visualizer"
+#define PLUGIN_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/lib"
 
 #define DELPHYNE_INITIAL_CONFIG_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/delphyne/layouts"
 


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196

Changes the plugin path variable to the install space. It worked with the old visualizer because all plugins were at ws/ build/delphyne_gui/visualizer folder but with the new one, each plugin is in its respective folder so it can't be found in focal. This change makes all (new and old visualizer, in bionic and in focal) to look for the plugins in the ws/install/delphyne_gui/lib folder instead.

