### PR TITLE
Replaces AMENT_CURRENT_PREFIX by COLCON_PREFIX_PATH

### DIFF
--- a/delphyne_gui/setup.sh.in
+++ b/delphyne_gui/setup.sh.in
@@ -52,10 +52,10 @@ add_if_not_in_var() {
 
 # Path to various resources used by shell/python scripts and demos
 #   e.g. configuration files, protos, road geometries
-add_if_not_in_var DELPHYNE_GUI_RESOURCE_ROOT $AMENT_CURRENT_PREFIX/share/delphyne
+add_if_not_in_var DELPHYNE_GUI_RESOURCE_ROOT $COLCON_PREFIX_PATH/delphyne_gui/share/delphyne
 
 # Path to visualizer plugins
-add_if_not_in_var VISUALIZER_PLUGIN_PATH $AMENT_CURRENT_PREFIX/lib
+add_if_not_in_var VISUALIZER_PLUGIN_PATH $COLCON_PREFIX_PATH/delphyne_gui/lib
 
 # Path to display plugins
-add_if_not_in_var IGN_GUI_DISPLAY_PLUGIN_PATH $AMENT_CURRENT_PREFIX/lib
+add_if_not_in_var IGN_GUI_DISPLAY_PLUGIN_PATH $COLCON_PREFIX_PATH/delphyne_gui/lib


### PR DESCRIPTION
AMENT_CURRENT_PREFIX points to /opt/ros/foxy in foxy whereas
it points to the full workspace/install/package_name in dashing.
COLCON_PREFIX_PATH remains to point to the full workspace/install
path.

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196 -- see this [comment](https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196)

Tested in focal and in bionic.

Also, I could verify that maliput_viewer2 works in focal and the error, which is tracked in  https://github.com/ToyotaResearchInstitute/delphyne_gui/issues/405, is not reproducible.