### PR TITLE
Removes ignition-gui0 and its dependencies from CI.

### DIFF
--- a/.github/ignition_packages_installation.sh
+++ b/.github/ignition_packages_installation.sh
@@ -58,7 +58,6 @@ function install_ignition_packages() {
 
   apt update
   apt install -y \
-    libignition-cmake1-dev \
     libignition-cmake2-dev \
     libignition-common3-dev \
     libignition-math6-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: install drake
       shell: bash

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: install drake
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: install drake
       shell: bash


### PR DESCRIPTION
With https://github.com/ToyotaResearchInstitute/delphyne_gui/pull/423 merged, ign-gui0 is no longer needed.

Part of #332 