### PR TITLE
Fixes layout selection.

### DIFF
--- a/delphyne_gui/python/utilities.py
+++ b/delphyne_gui/python/utilities.py
@@ -67,17 +67,7 @@ def launch_visualizer(launcher_manager, layout=None,
     ign_visualizer_args = []
     if layout:
         layout_key = "--layout="
-        layout_path = str()
-        if os.path.isabs(layout):
-            layout_path = layout
-        else:
-            layout_path = get_delphyne_gui_resource(
-                os.path.join("layouts", layout)
-            )
-            if layout_path == "":
-                # Then it could be relative to the execution folder.
-                layout_path = layout
-        ign_visualizer_args.append(layout_key + layout_path)
+        ign_visualizer_args.append(layout_key + resolve_layout_path(layout))
     # Force line buffering for child process.
     ign_visualizer_args.append("--use-line-buffer=yes")
     if plugin_injection:
@@ -87,6 +77,20 @@ def launch_visualizer(launcher_manager, layout=None,
     if bundle_path:
         ign_visualizer_args.append("--package=" + bundle_path)
     launcher_manager.launch([ign_visualizer] + ign_visualizer_args)
+
+
+def resolve_layout_path(layout):
+    layout_path = str()
+    if os.path.isabs(layout):
+        layout_path = layout
+    else:
+        layout_path = get_delphyne_gui_resource(
+            os.path.join("layouts", layout)
+        )
+        if layout_path == "":
+            # Then it could be relative to the execution folder.
+            layout_path = layout
+    return layout_path
 
 
 def get_delphyne_gui_resource_root():


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/delphyne/issues/806

The logic of the `launch_visualizer` method is improved to be able to load `layout`s not only from the `DELPHYNE_GUI_RESOURCE_ROOT` location but also if an absolute path is passed as well as a relative path from the execution folder.

This impacts on the demos (delphyne_demos) where now they can be executed using different layouts 
https://github.com/ToyotaResearchInstitute/delphyne_demos/pull/29