### PR TITLE
Improves default layouts and style.

### DIFF
--- a/delphyne_gui/visualizer/layout_for_playback.config
+++ b/delphyne_gui/visualizer/layout_for_playback.config
@@ -1,72 +1,21 @@
 <?xml version="1.0"?>
 
 <window>
-  <position_x>278</position_x>
-  <position_y>172</position_y>
-  <state>AAAA/wAAAAD9AAAAAQAAAAIAAAUwAAACxvwBAAAAAvwAAAAAAAADXwAAAtoA/////AIAAAAD+wAAABgAUgBlAG4AZABlAHIAVwBpAGQAZwBlAHQBAAAAFAAAAej/////AP///vsAAAAYAFQAbwBwAGkAYwBzACAAcwB0AGEAdABzAQAAAgIAAADYAAAAlgD////7AAAAFABUAGkAbQBlACAAcABhAG4AZQBsAQAAApQAAABGAAAAAAAAAAD8AAADZQAAAcsAAAFeAP////wCAAAAB/sAAAAYAFQAbwBwAGkAYwAgAHYAaQBlAHcAZQByAQAAABQAAACpAAAAlgD////7AAAAFABTAGMAZQBuAGUAIAB0AHIAZQBlAQAAAMMAAACnAAAAdgD////7AAAAEABEAGkAcwBwAGwAYQB5AHMBAAABcAAAAHYAAAB2AP////sAAAAIAFQAaQBtAGUBAAAB7AAAAGYAAABmAP////sAAAAYAFQAaQBtAGUAIABjAG8AbgB0AHIAbwBsAQAAAdkAAABeAAAAAAAAAAD7AAAAHgBUAG8AcABpAGMAIABpAG4AdABlAHIAZgBhAGMAZQEAAAHOAAAAewAAAAAAAAAA/AAAAlgAAACCAAAAggD////8AQAAAAL7AAAAGABUAGUAbABlAG8AcABXAGkAZABnAGUAdAEAAANlAAABywAAANgA////+wAAABgAVABlAGwAZQBvAHAAVwBpAGQAZwBlAHQAAAAERAAAAOwAAAAAAAAAAAAABTAAAAAAAAAABAAAAAQAAAAIAAAACPwAAAAA</state>
-  <width>1328</width>
-  <height>730</height>
-  <ignore>position</ignore>
-  <stylesheet>
-    /* ---------------------------- */
-    /*          VariablePill        */
-    /* ---------------------------- */
-
-    /* General */
-    ignition--gui--VariablePill
-    {
-      border-radius: 10px;
-      margin: 0px;
-    }
-
-    ignition--gui--VariablePill > QLabel
-    {
-      border-radius: 10px;
-      color: #ffffff;
-      padding-left: 8px;
-      padding-right: 8px;
-      padding-top: 2px;
-      padding-bottom: 2px;
-    }
-
-    /* Not selected pill */
-    ignition--gui--VariablePill[multiPillParent=false][selectedPill=false],
-    ignition--gui--VariablePill[multiPillParent=true][selectedPill=false] > QLabel
-    {
-      border: 1.5px solid #2196f3;
-    }
-
-    /* Selected pill */
-    ignition--gui--VariablePill[multiPillParent=false][selectedPill=true],
-    ignition--gui--VariablePill[multiPillParent=true][selectedPill=true] > QLabel
-    {
-      border: 1.5px solid #1565c0;
-    }
-
-    /* Not child */
-    ignition--gui--VariablePill[multiPillChild=false],
-    ignition--gui--VariablePill[multiPillParent=false][multiPillChild=false] > QLabel
-    {
-      border-radius: 10px;
-      border: 0.5px solid #2196f3;
-      background-color: #2196f3;
-    }
-
-    /* Child */
-    ignition--gui--VariablePill[multiPillChild=true],
-    ignition--gui--VariablePill[multiPillParent=true][multiPillChild=false] > QLabel
-    {
-      background-color: #64b5f6;
-    }
-
-    /* ---------------------------- */
-    /*           Buttons            */
-    /* ---------------------------- */
-    QPushButton#collapsibleButton
-    {
-      padding: 8px;
-    }
-  </stylesheet>
+  <width>1366</width>
+  <height>768</height>
+  <style
+    material_theme="Light"
+    material_primary="DeepOrange"
+    material_accent="LightBlue"
+    toolbar_color_light="#f3f3f3"
+    toolbar_text_color_light="#111111"
+    toolbar_color_dark="#414141"
+    toolbar_text_color_dark="#f3f3f3"
+    plugin_toolbar_color_light="#bbdefb"
+    plugin_toolbar_text_color_light="#111111"
+    plugin_toolbar_color_dark="#607d8b"
+    plugin_toolbar_text_color_dark="#eeeeee"
+  />
   <menus>
     <file/>
   </menus>
@@ -74,6 +23,7 @@
 </window>
 <plugin filename="Scene3D">
   <ignition-gui>
+    <title>Scene3D</title>
     <property type="bool" key="showTitleBar">false</property>
     <property type="bool" key="showCollapseButton">false</property>
     <property type="bool" key="showDockButton">false</property>
@@ -98,16 +48,31 @@
 
 <plugin filename="WorldStats">
   <ignition-gui>
-    <title>Real Time Factor</title>
-    <property type="bool" key="showCollapseButton">true</property>
-    <property type="bool" key="showDockButton">false</property>
-    <property type="bool" key="showCloseButton">false</property>
-    <property type="bool" key="showTitleBar">true</property>
-    <property type="bool" key="resizable">true</property>
+    <title>World stats</title>
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="bool" key="resizable">false</property>
+    <property type="double" key="height">110</property>
+    <property type="double" key="width">290</property>
+    <property type="double" key="z">1</property>
+
+    <property type="string" key="state">floating</property>
+    <anchors target="Scene3D">
+      <line own="right" target="right"/>
+      <line own="bottom" target="bottom"/>
+    </anchors>
   </ignition-gui>
   <real_time_factor>true</real_time_factor>
   <iterations>true</iterations>
   <topic>/world_stats</topic>
+</plugin>
+
+<plugin filename="PlaybackPlugin">
+  <ignition-gui>
+    <property type="bool" key="showCollapseButton">true</property>
+    <property type="bool" key="showDockButton">true</property>
+    <property type="bool" key="showCloseButton">true</property>
+    <property type="bool" key="resizable">true</property>
+  </ignition-gui>
 </plugin>
 
 <plugin filename="TopicInterfacePlugin" read_only="true">
@@ -163,27 +128,38 @@
   <hide>sky</hide>
 </plugin>
 
-<plugin filename="PlaybackPlugin">
-  <ignition-gui>
-    <property type="bool" key="showCollapseButton">true</property>
-    <property type="bool" key="showDockButton">false</property>
-    <property type="bool" key="showCloseButton">false</property>
-    <property type="bool" key="resizable">true</property>
-  </ignition-gui>
-</plugin>
 
 <plugin filename="TopicsStats"/>
 
 <plugin filename="TopicViewer">
   <ignition-gui>
     <property type="bool" key="showCollapseButton">true</property>
-    <property type="bool" key="showDockButton">false</property>
-    <property type="bool" key="showCloseButton">false</property>
+    <property type="bool" key="showDockButton">true</property>
+    <property type="bool" key="showCloseButton">true</property>
     <property type="bool" key="resizable">true</property>
   </ignition-gui>
 </plugin>
 
+<plugin filename="AgentInfoDisplay">
+  <ignition-gui>
+    <property key="state" type="string">docked_collapsed</property>
+  </ignition-gui>
+  <!-- Must match the same name as Scene3D plugin's scene parameter -->
+  <scene>scene</scene>
+</plugin>
+
+<plugin filename="OriginDisplay">
+  <ignition-gui>
+    <property key="state" type="string">docked_collapsed</property>
+  </ignition-gui>
+  <!-- Must match the same name as Scene3D plugin's scene parameter -->
+  <scene>scene</scene>
+</plugin>
+
 <plugin filename="Grid3D">
+  <ignition-gui>
+    <property key="state" type="string">docked_collapsed</property>
+  </ignition-gui>
   <engine>ogre</engine>
   <scene>scene</scene>
   <insert>

--- a/delphyne_gui/visualizer/layout_maliput_viewer.config
+++ b/delphyne_gui/visualizer/layout_maliput_viewer.config
@@ -1,72 +1,21 @@
 <?xml version="1.0"?>
 
 <window>
-  <position_x>278</position_x>
-  <position_y>172</position_y>
-  <state>AAAA/wAAAAD9AAAAAQAAAAIAAAUwAAACxvwBAAAAAvwAAAAAAAADXwAAAtoA/////AIAAAAD+wAAABgAUgBlAG4AZABlAHIAVwBpAGQAZwBlAHQBAAAAFAAAAej/////AP///vsAAAAYAFQAbwBwAGkAYwBzACAAcwB0AGEAdABzAQAAAgIAAADYAAAAlgD////7AAAAFABUAGkAbQBlACAAcABhAG4AZQBsAQAAApQAAABGAAAAAAAAAAD8AAADZQAAAcsAAAFeAP////wCAAAAB/sAAAAYAFQAbwBwAGkAYwAgAHYAaQBlAHcAZQByAQAAABQAAACpAAAAlgD////7AAAAFABTAGMAZQBuAGUAIAB0AHIAZQBlAQAAAMMAAACnAAAAdgD////7AAAAEABEAGkAcwBwAGwAYQB5AHMBAAABcAAAAHYAAAB2AP////sAAAAIAFQAaQBtAGUBAAAB7AAAAGYAAABmAP////sAAAAYAFQAaQBtAGUAIABjAG8AbgB0AHIAbwBsAQAAAdkAAABeAAAAAAAAAAD7AAAAHgBUAG8AcABpAGMAIABpAG4AdABlAHIAZgBhAGMAZQEAAAHOAAAAewAAAAAAAAAA/AAAAlgAAACCAAAAggD////8AQAAAAL7AAAAGABUAGUAbABlAG8AcABXAGkAZABnAGUAdAEAAANlAAABywAAANgA////+wAAABgAVABlAGwAZQBvAHAAVwBpAGQAZwBlAHQAAAAERAAAAOwAAAAAAAAAAAAABTAAAAAAAAAABAAAAAQAAAAIAAAACPwAAAAA</state>
-  <width>1328</width>
-  <height>730</height>
-  <ignore>position</ignore>
-  <stylesheet>
-    /* ---------------------------- */
-    /*          VariablePill        */
-    /* ---------------------------- */
-
-    /* General */
-    ignition--gui--VariablePill
-    {
-      border-radius: 10px;
-      margin: 0px;
-    }
-
-    ignition--gui--VariablePill > QLabel
-    {
-      border-radius: 10px;
-      color: #ffffff;
-      padding-left: 8px;
-      padding-right: 8px;
-      padding-top: 2px;
-      padding-bottom: 2px;
-    }
-
-    /* Not selected pill */
-    ignition--gui--VariablePill[multiPillParent=false][selectedPill=false],
-    ignition--gui--VariablePill[multiPillParent=true][selectedPill=false] > QLabel
-    {
-      border: 1.5px solid #2196f3;
-    }
-
-    /* Selected pill */
-    ignition--gui--VariablePill[multiPillParent=false][selectedPill=true],
-    ignition--gui--VariablePill[multiPillParent=true][selectedPill=true] > QLabel
-    {
-      border: 1.5px solid #1565c0;
-    }
-
-    /* Not child */
-    ignition--gui--VariablePill[multiPillChild=false],
-    ignition--gui--VariablePill[multiPillParent=false][multiPillChild=false] > QLabel
-    {
-      border-radius: 10px;
-      border: 0.5px solid #2196f3;
-      background-color: #2196f3;
-    }
-
-    /* Child */
-    ignition--gui--VariablePill[multiPillChild=true],
-    ignition--gui--VariablePill[multiPillParent=true][multiPillChild=false] > QLabel
-    {
-      background-color: #64b5f6;
-    }
-
-    /* ---------------------------- */
-    /*           Buttons            */
-    /* ---------------------------- */
-    QPushButton#collapsibleButton
-    {
-      padding: 8px;
-    }
-  </stylesheet>
+  <width>1366</width>
+  <height>768</height>
+  <style
+    material_theme="Light"
+    material_primary="DeepOrange"
+    material_accent="LightBlue"
+    toolbar_color_light="#f3f3f3"
+    toolbar_text_color_light="#111111"
+    toolbar_color_dark="#414141"
+    toolbar_text_color_dark="#f3f3f3"
+    plugin_toolbar_color_light="#bbdefb"
+    plugin_toolbar_text_color_light="#111111"
+    plugin_toolbar_color_dark="#607d8b"
+    plugin_toolbar_text_color_dark="#eeeeee"
+  />
   <menus>
     <file/>
   </menus>
@@ -96,11 +45,14 @@
   <camera_pose>-6 0 6 0 0.5 0</camera_pose>
 </plugin>
 
-<plugin filename="OriginDisplay">
-  <!-- Must match the same name as Scene3D plugin's scene parameter -->
-  <scene>scene</scene>
-</plugin>
-
 <plugin filename="MaliputViewerPlugin">
   <main_scene_plugin_title>Main3DScene</main_scene_plugin_title>
+</plugin>
+
+<plugin filename="OriginDisplay">
+  <ignition-gui>
+    <property key="state" type="string">docked_collapsed</property>
+  </ignition-gui>
+  <!-- Must match the same name as Scene3D plugin's scene parameter -->
+  <scene>scene</scene>
 </plugin>

--- a/delphyne_gui/visualizer/layout_with_teleop.config
+++ b/delphyne_gui/visualizer/layout_with_teleop.config
@@ -1,72 +1,21 @@
 <?xml version="1.0"?>
 
 <window>
-  <position_x>278</position_x>
-  <position_y>172</position_y>
-  <state>AAAA/wAAAAD9AAAAAQAAAAIAAAUwAAACxvwBAAAAAvwAAAAAAAADXwAAAtoA/////AIAAAAD+wAAABgAUgBlAG4AZABlAHIAVwBpAGQAZwBlAHQBAAAAFAAAAej/////AP///vsAAAAYAFQAbwBwAGkAYwBzACAAcwB0AGEAdABzAQAAAgIAAADYAAAAlgD////7AAAAFABUAGkAbQBlACAAcABhAG4AZQBsAQAAApQAAABGAAAAAAAAAAD8AAADZQAAAcsAAAFeAP////wCAAAAB/sAAAAYAFQAbwBwAGkAYwAgAHYAaQBlAHcAZQByAQAAABQAAACpAAAAlgD////7AAAAFABTAGMAZQBuAGUAIAB0AHIAZQBlAQAAAMMAAACnAAAAdgD////7AAAAEABEAGkAcwBwAGwAYQB5AHMBAAABcAAAAHYAAAB2AP////sAAAAIAFQAaQBtAGUBAAAB7AAAAGYAAABmAP////sAAAAYAFQAaQBtAGUAIABjAG8AbgB0AHIAbwBsAQAAAdkAAABeAAAAAAAAAAD7AAAAHgBUAG8AcABpAGMAIABpAG4AdABlAHIAZgBhAGMAZQEAAAHOAAAAewAAAAAAAAAA/AAAAlgAAACCAAAAggD////8AQAAAAL7AAAAGABUAGUAbABlAG8AcABXAGkAZABnAGUAdAEAAANlAAABywAAANgA////+wAAABgAVABlAGwAZQBvAHAAVwBpAGQAZwBlAHQAAAAERAAAAOwAAAAAAAAAAAAABTAAAAAAAAAABAAAAAQAAAAIAAAACPwAAAAA</state>
-  <width>1328</width>
-  <height>730</height>
-  <ignore>position</ignore>
-  <stylesheet>
-    /* ---------------------------- */
-    /*          VariablePill        */
-    /* ---------------------------- */
-
-    /* General */
-    ignition--gui--VariablePill
-    {
-      border-radius: 10px;
-      margin: 0px;
-    }
-
-    ignition--gui--VariablePill > QLabel
-    {
-      border-radius: 10px;
-      color: #ffffff;
-      padding-left: 8px;
-      padding-right: 8px;
-      padding-top: 2px;
-      padding-bottom: 2px;
-    }
-
-    /* Not selected pill */
-    ignition--gui--VariablePill[multiPillParent=false][selectedPill=false],
-    ignition--gui--VariablePill[multiPillParent=true][selectedPill=false] > QLabel
-    {
-      border: 1.5px solid #2196f3;
-    }
-
-    /* Selected pill */
-    ignition--gui--VariablePill[multiPillParent=false][selectedPill=true],
-    ignition--gui--VariablePill[multiPillParent=true][selectedPill=true] > QLabel
-    {
-      border: 1.5px solid #1565c0;
-    }
-
-    /* Not child */
-    ignition--gui--VariablePill[multiPillChild=false],
-    ignition--gui--VariablePill[multiPillParent=false][multiPillChild=false] > QLabel
-    {
-      border-radius: 10px;
-      border: 0.5px solid #2196f3;
-      background-color: #2196f3;
-    }
-
-    /* Child */
-    ignition--gui--VariablePill[multiPillChild=true],
-    ignition--gui--VariablePill[multiPillParent=true][multiPillChild=false] > QLabel
-    {
-      background-color: #64b5f6;
-    }
-
-    /* ---------------------------- */
-    /*           Buttons            */
-    /* ---------------------------- */
-    QPushButton#collapsibleButton
-    {
-      padding: 8px;
-    }
-  </stylesheet>
+  <width>1366</width>
+  <height>768</height>
+  <style
+    material_theme="Light"
+    material_primary="DeepOrange"
+    material_accent="LightBlue"
+    toolbar_color_light="#f3f3f3"
+    toolbar_text_color_light="#111111"
+    toolbar_color_dark="#414141"
+    toolbar_text_color_dark="#f3f3f3"
+    plugin_toolbar_color_light="#bbdefb"
+    plugin_toolbar_text_color_light="#111111"
+    plugin_toolbar_color_dark="#607d8b"
+    plugin_toolbar_text_color_dark="#eeeeee"
+  />
   <menus>
     <file/>
   </menus>
@@ -74,6 +23,7 @@
 </window>
 <plugin filename="Scene3D">
   <ignition-gui>
+    <title>Scene3D</title>
     <property type="bool" key="showTitleBar">false</property>
     <property type="bool" key="showCollapseButton">false</property>
     <property type="bool" key="showDockButton">false</property>
@@ -99,12 +49,19 @@
 <plugin filename="WorldControl">
   <ignition-gui>
     <title>Play/Pause</title>
-    <property type="bool" key="showCollapseButton">true</property>
-    <property type="bool" key="showDockButton">false</property>
-    <property type="bool" key="showCloseButton">false</property>
-    <property type="double" key="height">72</property>
-    <property type="double" key="width">121</property>
+
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="bool" key="resizable">false</property>
+    <property type="double" key="height">80</property>
+    <property type="double" key="width">130</property>
     <property type="double" key="z">1</property>
+    <property key="leftPadding" type="double">10</property>
+
+    <property type="string" key="state">floating</property>
+    <anchors target="Scene3D">
+      <line own="left" target="left"/>
+      <line own="bottom" target="bottom"/>
+    </anchors>
   </ignition-gui>
   <play_pause>true</play_pause>
   <start_paused>false</start_paused>
@@ -114,53 +71,22 @@
 
 <plugin filename="WorldStats">
   <ignition-gui>
-    <title>Real Time Factor</title>
-    <property type="bool" key="showCollapseButton">true</property>
-    <property type="bool" key="showDockButton">false</property>
-    <property type="bool" key="showCloseButton">false</property>
-    <property type="bool" key="showTitleBar">true</property>
-    <property type="bool" key="resizable">true</property>
+    <title>World stats</title>
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="bool" key="resizable">false</property>
+    <property type="double" key="height">110</property>
+    <property type="double" key="width">290</property>
+    <property type="double" key="z">1</property>
+
+    <property type="string" key="state">floating</property>
+    <anchors target="Scene3D">
+      <line own="right" target="right"/>
+      <line own="bottom" target="bottom"/>
+    </anchors>
   </ignition-gui>
   <real_time_factor>true</real_time_factor>
   <iterations>true</iterations>
   <topic>/world_stats</topic>
-</plugin>
-
-<plugin filename="TopicsStats"/>
-
-<plugin filename="TopicViewer">
-  <ignition-gui>
-    <property type="bool" key="showCollapseButton">true</property>
-    <property type="bool" key="showDockButton">false</property>
-    <property type="bool" key="showCloseButton">false</property>
-    <property type="bool" key="resizable">true</property>
-  </ignition-gui>
-</plugin>
-
-<plugin filename="Grid3D">
-  <engine>ogre</engine>
-  <scene>scene</scene>
-  <insert>
-    <cell_count>250</cell_count>
-    <vertical_cell_count>0</vertical_cell_count>
-    <cell_length>1.000000</cell_length>
-    <pose>0 0 0 0 0 0</pose>
-    <color>0.7 0.7 0.7 0.3</color>
-  </insert>
-</plugin>
-
-<plugin filename="TeleopPlugin">
-  <car_number>0</car_number>
-</plugin>
-
-<plugin filename="AgentInfoDisplay">
-  <!-- Must match the same name as Scene3D plugin's scene parameter -->
-  <scene>scene</scene>
-</plugin>
-
-<plugin filename="OriginDisplay">
-  <!-- Must match the same name as Scene3D plugin's scene parameter -->
-  <scene>scene</scene>
 </plugin>
 
 <plugin filename="TopicInterfacePlugin" read_only="true">
@@ -214,4 +140,55 @@
   <hide>origin_visual</hide>
   <hide>shadows</hide>
   <hide>sky</hide>
+</plugin>
+
+<plugin filename="TopicsStats">
+  <ignition-gui>
+  </ignition-gui>
+</plugin>
+
+<plugin filename="TopicViewer">
+  <ignition-gui>
+    <property type="bool" key="showCollapseButton">true</property>
+    <property type="bool" key="showDockButton">true</property>
+    <property type="bool" key="showCloseButton">true</property>
+    <property type="bool" key="resizable">true</property>
+  </ignition-gui>
+</plugin>
+
+<plugin filename="TeleopPlugin">
+  <ignition-gui>
+  </ignition-gui>
+  <car_number>0</car_number>
+</plugin>
+
+<plugin filename="AgentInfoDisplay">
+  <ignition-gui>
+    <property key="state" type="string">docked_collapsed</property>
+  </ignition-gui>
+  <!-- Must match the same name as Scene3D plugin's scene parameter -->
+  <scene>scene</scene>
+</plugin>
+
+<plugin filename="OriginDisplay">
+  <ignition-gui>
+    <property key="state" type="string">docked_collapsed</property>
+  </ignition-gui>
+  <!-- Must match the same name as Scene3D plugin's scene parameter -->
+  <scene>scene</scene>
+</plugin>
+
+<plugin filename="Grid3D">
+  <ignition-gui>
+    <property key="state" type="string">docked_collapsed</property>
+  </ignition-gui>
+  <engine>ogre</engine>
+  <scene>scene</scene>
+  <insert>
+    <cell_count>250</cell_count>
+    <vertical_cell_count>0</vertical_cell_count>
+    <cell_length>1.000000</cell_length>
+    <pose>0 0 0 0 0 0</pose>
+    <color>0.7 0.7 0.7 0.3</color>
+  </insert>
 </plugin>


### PR DESCRIPTION
Improve layouts and style:
 - Play/Pause is floating in the scene(bottom/left) to avoid wasting space in the dock.
 - Real Time Factor is floating in the scene(bottom/right) to avoid wasting space in the dock.
 - The plugins were reorganized to first list the "important" ones and leave collapsed the rest (being the rested plugins like OriginDisplay, AgentInfoDisplay, Grid3D )
- Style was changed. I feel it more formal than previous colours. WDYT?@agalbachicar  It can easily reverted.

--------------------------------------------
layout_for_teleop.config
![image](https://user-images.githubusercontent.com/53065142/134991661-7b021ba3-4452-49d2-9fdf-08abf7879a87.png)
layout_for_replay.config
![image](https://user-images.githubusercontent.com/53065142/134991694-ae878f0a-023a-4ea6-b1f9-49bf70f878e2.png)
layout_for_maliput_viewer.config
![image](https://user-images.githubusercontent.com/53065142/134991732-27d2c33e-0b65-4da4-997f-8685114942c7.png)
