### PR TITLE
Maliput Viewer: Supports selecting RuleRegistry and IntersectionBook files

### DIFF
--- a/delphyne_gui/visualizer/maliput_viewer_plugin/FileSelectionArea.qml
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/FileSelectionArea.qml
@@ -9,6 +9,7 @@ import QtQuick.Layouts 1.3
 
 // Panel that contains four buttons for selecting:
 // - Map file.
+// - RuleRegistry file.
 // - RoadRulebook file.
 // - TrafficLightBook file.
 // - PhaseRingBook file.
@@ -23,6 +24,9 @@ GridLayout {
   anchors.topMargin: 10
   Layout.fillWidth: true
 
+  // Path to the RuleRegistry file.
+  property string ruleRegistryPath: ""
+
   // Path to the RoadRulebook file.
   property string roadRulebookPath: ""
 
@@ -31,6 +35,9 @@ GridLayout {
 
   // Path to the PhaseRingBook file.
   property string phaseRingBookPath: ""
+
+  // Path to the IntersectionBook file.
+  property string intersectionBookPath: ""
 
   // Path to the map file.
   property string mapFilePath: ""
@@ -44,6 +51,57 @@ GridLayout {
     Layout.alignment: Qt.AlignHCenter
     font.pixelSize: 14
     text: "FILES SELECTION"
+  }
+
+  /**
+  * RuleRegistry selecting button
+  */
+  FileDialog {
+    id: ruleRegistryDialog
+    title: "Please choose a RuleRegistry"
+    nameFilters: [ "YAML files (*.yaml)", "All files (*)" ]
+    selectExisting : true
+    selectFolder : false
+    selectMultiple : false
+    sidebarVisible : true
+    onAccepted: {
+      console.log("RuleRegistry selection: You chose: " + ruleRegistryDialog.fileUrl)
+      ruleRegistryPath = ruleRegistryDialog.fileUrl
+    }
+    onRejected: {
+      console.log("RuleRegistry selection: Canceled")
+    }
+    visible: false
+  }
+  TextField {
+    id: ruleRegistryPathTextField
+    Layout.fillWidth: true
+    readOnly: true
+    text: ruleRegistryPath
+    placeholderText: qsTr("Optional: Select a RuleRegistry file...")
+    font.pixelSize: 12
+    font.family: "Helvetica"
+  }
+  Button {
+    id: ruleRegistryButton
+    text: "RuleRegistry"
+    checkable: false
+    Layout.preferredWidth: parent.width * 0.3
+    onClicked: {
+      ruleRegistryDialog.visible = true
+    }
+    Material.background: Material.primary
+    style: ButtonStyle {
+      label: Text {
+        renderType: Text.NativeRendering
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignHCenter
+        font.family: "Helvetica"
+        font.pointSize: 10
+        color: "black"
+        text: ruleRegistryButton.text
+      }
+    }
   }
 
   /**
@@ -200,6 +258,57 @@ GridLayout {
   }
 
   /**
+  * Intersection book selecting button
+  */
+  FileDialog {
+    id: intersectionBookDialog
+    title: "Please choose a IntersectionBook"
+    nameFilters: [ "YAML files (*.yaml)", "All files (*)" ]
+    selectExisting : true
+    selectFolder : false
+    selectMultiple : false
+    sidebarVisible : true
+    onAccepted: {
+      console.log("IntersectionBook selection: You chose: " + intersectionBookDialog.fileUrl)
+      intersectionBookPath = intersectionBookDialog.fileUrl
+    }
+    onRejected: {
+      console.log("IntersectionBook selection: Canceled")
+    }
+    visible: false
+  }
+  TextField {
+    id: intersectionBookPathTextField
+    Layout.fillWidth: true
+    readOnly: true
+    text: intersectionBookPath
+    placeholderText: qsTr("Optional: Select a IntersectionBook file...")
+    font.pixelSize: 12
+    font.family: "Helvetica"
+  }
+  Button {
+    id: intersectionBookButton
+    text: "IntersectionBook"
+    checkable: false
+    Layout.preferredWidth: parent.width * 0.3
+    onClicked: {
+      intersectionBookDialog.visible = true
+    }
+    Material.background: Material.primary
+    style: ButtonStyle {
+      label: Text {
+        renderType: Text.NativeRendering
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignHCenter
+        font.family: "Helvetica"
+        font.pointSize: 10
+        color: "black"
+        text: intersectionBookButton.text
+      }
+    }
+  }
+
+  /**
   * Mapfile selecting button
   */
   FileDialog {
@@ -261,7 +370,7 @@ GridLayout {
     Layout.columnSpan: 2
     Layout.fillWidth: true
     onClicked: {
-      MaliputViewerPlugin.OnNewRoadNetwork(mapFilePath, roadRulebookPath, trafficLightBookPath, phaseRingBookPath)
+      MaliputViewerPlugin.OnNewRoadNetwork(mapFilePath, ruleRegistryPath, roadRulebookPath, trafficLightBookPath, phaseRingBookPath, intersectionBookPath)
     }
     Material.background: Material.primary
     style: ButtonStyle {

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/MaliputViewerPlugin.qml
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/MaliputViewerPlugin.qml
@@ -10,7 +10,7 @@ Rectangle {
   id: maliputViewerPlugin
   Layout.minimumWidth: 400
   Layout.preferredWidth: 450
-  Layout.minimumHeight: 1150
+  Layout.minimumHeight: 1250
   anchors.fill: parent
 
   // Files Selection Panel

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/RulesListArea.qml
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/RulesListArea.qml
@@ -31,8 +31,8 @@ GridLayout {
     Layout.alignment: Qt.AlignVTop | Qt.AlignHLeft
     width: parent.width
     Layout.minimumHeight: 100
-    Layout.preferredHeight: 125
-    Layout.maximumHeight: 125
+    Layout.preferredHeight: 175
+    Layout.maximumHeight: 175
     Layout.fillWidth: true
     font.pixelSize: 12
     font.family: "Helvetica"

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.cc
@@ -375,12 +375,14 @@ maliput::api::rules::RoadRulebook::QueryResults RoadNetworkQuery::FindRulesFor(c
 }
 
 /////////////////////////////////////////////////
-bool MaliputViewerModel::Load(const std::string& _maliputFilePath, const std::string& _roadRulebookFilePath,
-                              const std::string& _trafficLightBookFilePath, const std::string& _phaseRingFilePath) {
+bool MaliputViewerModel::Load(const std::string& _maliputFilePath, const std::string& _ruleRegistryFilePath,
+                              const std::string& _roadRulebookFilePath, const std::string& _trafficLightBookFilePath,
+                              const std::string& _phaseRingFilePath, const std::string& _intersectionBookFilePath) {
   this->Clear();
 
   ignmsg << "About to load [" << _maliputFilePath << "] maliput file." << std::endl;
-  LoadRoadGeometry(_maliputFilePath, _roadRulebookFilePath, _trafficLightBookFilePath, _phaseRingFilePath);
+  LoadRoadGeometry(_maliputFilePath, _ruleRegistryFilePath, _roadRulebookFilePath, _trafficLightBookFilePath,
+                   _phaseRingFilePath, _intersectionBookFilePath);
   const maliput::api::RoadGeometry* rg = roadNetwork->road_geometry();
   ignmsg << "Loaded [" << _maliputFilePath << "] maliput file." << std::endl;
   ignmsg << "Loading RoadGeometry meshes of " << rg->id().string() << std::endl;
@@ -411,9 +413,11 @@ const std::map<std::string, std::unique_ptr<MaliputMesh>>& MaliputViewerModel::M
 const std::map<std::string, MaliputLabel>& MaliputViewerModel::Labels() const { return this->labels; }
 
 /////////////////////////////////////////////////
-void MaliputViewerModel::LoadRoadGeometry(const std::string& _maliputFilePath, const std::string& _roadRulebookFilePath,
+void MaliputViewerModel::LoadRoadGeometry(const std::string& _maliputFilePath, const std::string& _ruleRegistryFilePath,
+                                          const std::string& _roadRulebookFilePath,
                                           const std::string& _trafficLightBookFilePath,
-                                          const std::string& _phaseRingFilePath) {
+                                          const std::string& _phaseRingFilePath,
+                                          const std::string& _intersectionBookFilePath) {
   std::ifstream fileStream(_maliputFilePath);
   if (!fileStream.is_open()) {
     throw std::runtime_error(_maliputFilePath + " doesn't exist or can't be opened.");
@@ -423,8 +427,8 @@ void MaliputViewerModel::LoadRoadGeometry(const std::string& _maliputFilePath, c
     std::getline(fileStream, line);
     if (line.find("<OpenDRIVE>") != std::string::npos) {
       this->roadNetwork = delphyne::roads::CreateMalidriveRoadNetworkFromXodr(
-          _maliputFilePath.substr(_maliputFilePath.find_last_of("/") + 1), _maliputFilePath, _roadRulebookFilePath,
-          _trafficLightBookFilePath, _phaseRingFilePath);
+          _maliputFilePath.substr(_maliputFilePath.find_last_of("/") + 1), _maliputFilePath, _ruleRegistryFilePath,
+          _roadRulebookFilePath, _trafficLightBookFilePath, _phaseRingFilePath, _intersectionBookFilePath);
       return;
     } else if (line.find("maliput_multilane_builder:") != std::string::npos) {
       this->roadNetwork = delphyne::roads::CreateMultilaneFromFile(_maliputFilePath);

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.hh
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.hh
@@ -179,9 +179,10 @@ class MaliputViewerModel {
   /// Gets the file path from GlobalAttributes and loads the RoadGeometry into
   /// memory. Then, converts it into a map of meshes, loading each mesh material
   /// information. Meshes that are not available, are set to kDisabled.
-  bool Load(const std::string& _maliputFilePath, const std::string& _roadRulebookFilePath = std::string(),
-            const std::string& _trafficLightBook = std::string(),
-            const std::string& _phaseRingFilePath = std::string());
+  bool Load(const std::string& _maliputFilePath, const std::string& _ruleRegistryFilePath = std::string(),
+            const std::string& _roadRulebookFilePath = std::string(),
+            const std::string& _trafficLightBook = std::string(), const std::string& _phaseRingFilePath = std::string(),
+            const std::string& _intersectionBookFilePath = std::string());
 
   /// \return True when any of roadNetwork are not nullptr.
   bool IsInitialized() const { return roadNetwork.get() != nullptr; }
@@ -277,8 +278,9 @@ class MaliputViewerModel {
   /// If the key doesn't exist in the file, it's not valid.
   /// Otherwise the correct loader will be called to parse the file.
   /// \param _maliputFilePath The YAML file path to parse.
-  void LoadRoadGeometry(const std::string& _maliputFilePath, const std::string& _roadRulebookFilePath,
-                        const std::string& _trafficLightBookFilePath, const std::string& _phaseRingFilePath);
+  void LoadRoadGeometry(const std::string& _maliputFilePath, const std::string& _ruleRegistryFilePath,
+                        const std::string& _roadRulebookFilePath, const std::string& _trafficLightBookFilePath,
+                        const std::string& _phaseRingFilePath, const std::string& _intersectionBookFilePath);
 
   /// \brief Converts @p _geoMeshes into a
   ///        std::map<std::string, std::unique_ptr<ignition::common::Mesh>>

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.cc
@@ -138,18 +138,22 @@ QList<bool> MaliputViewerPlugin::LabelCheckboxes() const {
   return {true /* lane */, true /* branch_point */};
 }
 
-void MaliputViewerPlugin::OnNewRoadNetwork(const QString& _mapFile, const QString& _roadRulebookFile,
-                                           const QString& _trafficLightBookFile, const QString& _phaseRingBookFile) {
+void MaliputViewerPlugin::OnNewRoadNetwork(const QString& _mapFile, const QString& _ruleRegistryFile,
+                                           const QString& _roadRulebookFile, const QString& _trafficLightBookFile,
+                                           const QString& _phaseRingBookFile, const QString& _intersectionBookFile) {
   if (_mapFile.isEmpty()) {
     ignerr << "Select the map file before clicking the LOAD button." << std::endl;
     return;
   }
   Clear();
   mapFile = GetPathFromFileUrl(_mapFile.toStdString());
+  ruleRegistryFile = GetPathFromFileUrl(_ruleRegistryFile.toStdString());
   roadRulebookFile = GetPathFromFileUrl(_roadRulebookFile.toStdString());
   trafficLightBookFile = GetPathFromFileUrl(_trafficLightBookFile.toStdString());
   phaseRingBookFile = GetPathFromFileUrl(_phaseRingBookFile.toStdString());
-  model->Load(mapFile, roadRulebookFile, trafficLightBookFile, phaseRingBookFile);
+  intersectionBookFile = GetPathFromFileUrl(_intersectionBookFile.toStdString());
+  model->Load(mapFile, ruleRegistryFile, roadRulebookFile, trafficLightBookFile, phaseRingBookFile,
+              intersectionBookFile);
   UpdateLaneList();
   emit LayerCheckboxesChanged();
   emit LabelCheckboxesChanged();

--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.hh
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_plugin.hh
@@ -159,11 +159,14 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
  protected slots:
   /// \brief Clears the visualizer, loads a RoadNetwork and update the GUI with meshes and labels.
   /// \param[in] _mapFile The path to the map file to load and visualize.
+  /// \param[in] _ruleRegistryFile The path to the rule registry file.
   /// \param[in] _roadRulebookFile The path to the road rulebook file.
   /// \param[in] _trafficLightBookFile The path to the traffic light book file.
   /// \param[in] _phaseRingBookFile The path to the phase ring book file.
-  void OnNewRoadNetwork(const QString& _mapFile, const QString& _roadRulebookFile, const QString& _trafficLightBookFile,
-                        const QString& _phaseRingBookFile);
+  /// \param[in] _intersectionBookFile The path to the phase ring book file.
+  void OnNewRoadNetwork(const QString& _mapFile, const QString& _ruleRegistryFile, const QString& _roadRulebookFile,
+                        const QString& _trafficLightBookFile, const QString& _phaseRingBookFile,
+                        const QString& _intersectionBookFile);
 
   /// \brief Change the visibility of the layers.
   /// \param[in] _layer The layer to change its visibility.
@@ -342,6 +345,9 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
   /// \brief Holds the map file path.
   std::string mapFile{""};
 
+  /// \brief Holds the rule registry file path.
+  std::string ruleRegistryFile{""};
+
   /// \brief Holds the road rulebook file path.
   std::string roadRulebookFile{""};
 
@@ -350,6 +356,9 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
 
   /// \brief Holds the phase ring book file path.
   std::string phaseRingBookFile{""};
+
+  /// \brief Holds the phase intersection book file path.
+  std::string intersectionBookFile{""};
 
   /// \brief Holds the lanes id that are shown in the table.
   ///        The order in this collection will affect the order


### PR DESCRIPTION
Depends on
 - https://github.com/ToyotaResearchInstitute/delphyne/pull/822
 - https://github.com/ToyotaResearchInstitute/maliput_malidrive/pull/200
 
Extends maliput viewer's loading support for RuleRegistry and IntersectionBook files

![image](https://user-images.githubusercontent.com/53065142/154071475-20e9720b-5d1a-422e-9141-b2bf2656cded.png)



Note: It is expected that the Maliput viewer's "file selection area" will evolve to https://github.com/ToyotaResearchInstitute/delphyne_gui/issues/427
 
 
