### PR TITLE
Changed values() and ranges() method from Rules to states()

### DIFF
--- a/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.cc
+++ b/delphyne_gui/visualizer/maliput_viewer_plugin/maliput_viewer_model.cc
@@ -200,7 +200,7 @@ void RoadNetworkQuery::GetDiscreteValue(const maliput::api::LaneId& lane_id) {
   const int n_rules = static_cast<int>(query_result.discrete_value_rules.size());
   if (n_rules > 0) {
     for (const auto& discrete_value_rule : query_result.discrete_value_rules) {
-      const auto& values = discrete_value_rule.second.values();
+      const auto& values = discrete_value_rule.second.states();
       for (const auto& value : values) {
         const std::string val = value.value;
         (*out_) << "              : Result: Rule (id: " << discrete_value_rule.first.string();
@@ -223,7 +223,7 @@ void RoadNetworkQuery::GetRangeValue(const maliput::api::LaneId& lane_id) {
   const int n_rules = static_cast<int>(query_result.range_value_rules.size());
   if (n_rules > 0) {
     for (const auto& range_value_rule : query_result.range_value_rules) {
-      const auto& ranges = range_value_rule.second.ranges();
+      const auto& ranges = range_value_rule.second.states();
       for (const auto& range : ranges) {
         const std::string description = range.description;
         const double min = range.min;


### PR DESCRIPTION
This PR is a follow up of the [PR](https://github.com/ToyotaResearchInstitute/maliput/pull/484) that solves https://github.com/ToyotaResearchInstitute/maliput/issues/472

**Description**
Exactly what the tittle says. Changes the method name of `DiscreteValueRule::values()` to `DiscreteValueRule::states()` and `RangeValueRule::ranges()` to `RangeValueRule::states()`.

