### PR TITLE
maliput_viewer: Supports maliput_osm's maps.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -27,6 +27,14 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput_multilane
     version: main
+  maliput_sparse:
+    type: git
+    url: https://github.com/maliput/maliput_sparse
+    version: main
+  maliput_osm:
+    type: git
+    url: https://github.com/maliput/maliput_osm
+    version: main
   maliput_py:
     type: git
     url: https://github.com/maliput/maliput_py

--- a/visualizer/maliput_viewer_plugin/FileSelectionArea.qml
+++ b/visualizer/maliput_viewer_plugin/FileSelectionArea.qml
@@ -342,7 +342,7 @@ GridLayout {
   FileDialog {
     id: mapFileDialog
     title: "Please choose a map to load"
-    nameFilters: [ "XODR files (*.xodr)", "YAML files (*.yaml)", "All files (*)" ]
+    nameFilters: [ "XODR files (*.xodr)", "OSM files (*.osm)", "YAML files (*.yaml)", "All files (*)" ]
     selectExisting : true
     selectFolder : false
     selectMultiple : false
@@ -362,7 +362,7 @@ GridLayout {
     Layout.fillWidth: true
     readOnly: true
     text: mapFilePath
-    placeholderText: qsTr("Select an XODR or YAML map file...")
+    placeholderText: qsTr("Select an XODR, OSM, or YAML map file...")
     font.pixelSize: 12
     font.family: "Helvetica"
   }

--- a/visualizer/maliput_viewer_plugin/maliput_viewer_model.cc
+++ b/visualizer/maliput_viewer_plugin/maliput_viewer_model.cc
@@ -453,6 +453,8 @@ void MaliputViewerModel::LoadRoadGeometry(const std::string& _maliputFilePath, c
   std::string line;
   while (!fileStream.eof()) {
     std::getline(fileStream, line);
+    // TODO(#427): When the viewer is able to receive a dictionary of string for the configuration,
+    //             this should change to use directly #maliput::plugin::CreateRoadNetwork("<maliput_backend>", config);
     if (line.find("<OpenDRIVE>") != std::string::npos) {
       this->roadNetwork = delphyne::roads::CreateMalidriveRoadNetworkFromXodr(
           _maliputFilePath.substr(_maliputFilePath.find_last_of("/") + 1), _maliputFilePath, _ruleRegistryFilePath,
@@ -460,6 +462,12 @@ void MaliputViewerModel::LoadRoadGeometry(const std::string& _maliputFilePath, c
       return;
     } else if (line.find("maliput_multilane_builder:") != std::string::npos) {
       this->roadNetwork = delphyne::roads::CreateMultilaneFromFile(_maliputFilePath);
+      return;
+    } else if (line.find("<osm version=") != std::string::npos) {
+      this->roadNetwork = delphyne::roads::CreateMaliputOSMRoadNetwork(
+          _maliputFilePath.substr(_maliputFilePath.find_last_of("/") + 1), _maliputFilePath, {} /* origin */,
+          _ruleRegistryFilePath, _roadRulebookFilePath, _trafficLightBookFilePath, _phaseRingFilePath,
+          _intersectionBookFilePath);
       return;
     }
   }


### PR DESCRIPTION
# 🎉 New feature

Relies on https://github.com/maliput/delphyne/pull/855

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
Supports loading `maliput_osm`'s maps. This is particularly useful for the creation of new osm.

## Test it
Run `maliput_viewer` and load a osm file from the gui.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
